### PR TITLE
Disable rabbitmq clustering by default

### DIFF
--- a/charts/opennotificaties/Chart.yaml
+++ b/charts/opennotificaties/Chart.yaml
@@ -3,7 +3,7 @@ name: opennotificaties
 description: API voor het routeren van notificaties
 
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.4.3
 
 dependencies:

--- a/charts/opennotificaties/values.yaml
+++ b/charts/opennotificaties/values.yaml
@@ -298,8 +298,18 @@ rabbitmq:
     username: user
     password: ""
     erlangCookie: ""
-
   persistence:
     enabled: false
     size: 1Gi
     existingClaim: null
+  resources: {}
+    # limits:
+    #   memory: 1000Mi
+    #   cpu: 500m
+    # requests:
+    #   memory: 600Mi
+    #   cpu: 200m    
+  rbac:
+    create: false
+  clustering:
+    enabled: false


### PR DESCRIPTION
By default  bitname/rabbitmq subchart tries to create rbac roles, requiring cluster admin permissions. 

Disable rbac create:
```
rbac.create: false
```

Clustering needs to be disabled when not using rbac or else the rabbitmq pod will fail.
```
clustering.enabled: false
```

