### PR TITLE
Openforms cors nginx

### DIFF
--- a/charts/openforms/Chart.yaml
+++ b/charts/openforms/Chart.yaml
@@ -3,7 +3,7 @@ name: openforms
 description: Snel en eenvoudig slimme formulieren bouwen en publiceren
 
 type: application
-version: 1.1.8
+version: 1.1.9
 appVersion: 2.0.5
 
 dependencies:

--- a/charts/openforms/templates/configmap-nginx.yaml
+++ b/charts/openforms/templates/configmap-nginx.yaml
@@ -24,6 +24,15 @@ data:
   default.conf: |
     # Rate limiting configuration - allow 1 request per second. 10m can track about 80000 clients.
     limit_req_zone $binary_remote_addr zone={{ include "openforms.fullname" . }}.{{ .Release.Namespace }}_discover:10m rate=1r/s;
+
+    {{ if .Values.settings.cors.allowedOriginsNginx | default false }}
+    map $http_origin $allow_origin {
+    ~^https?://(.*\.)?({{  join "|" .Values.settings.cors.allowedOrigins | toString }})(:\d+)?$ $http_origin;
+    # NGINX won't set empty string headers, so if no match, header is unset.
+    default "";
+    }
+    {{- end }}
+
     server {
         listen 8080 default_server;
         server_name {{ .Values.settings.allowedHosts  | replace "," " "}} localhost;
@@ -60,6 +69,9 @@ data:
         gzip_vary           on;
 
         location / {
+            {{- if .Values.settings.cors.allowedOriginsNginx | default false }}
+            add_header 'Access-Control-Allow-Origin' $allow_origin;
+            {{ end }}
             include conf.d/proxy;
         }
 

--- a/charts/openforms/templates/configmap-nginx.yaml
+++ b/charts/openforms/templates/configmap-nginx.yaml
@@ -100,8 +100,8 @@ data:
       }
 
 
-      location ~* .(eot|otf|svg|ttf|woff|woff2)$ {
-          add_header 'Access-Control-Allow-Origin' '*';
+      location ~* ^/static/.*\.(eot|ttf|woff|woff2|svg)$ {
+          add_header Access-Control-Allow-Origin *;
           include conf.d/proxy;
       }
     }

--- a/charts/openforms/values.yaml
+++ b/charts/openforms/values.yaml
@@ -176,6 +176,9 @@ settings:
   cors:
     # if defining the cors hosts, always include the own URL!
     allowAllOrigins: false
+    # Override headers in nginx
+    # Will add Access-Control-Allow-Origin header for defined allowedOrigins in Nginx (not recommended)
+    allowedOriginsNginx: false
     # allowedOrigins:
     #   - "https://openformulieren.gemeente.nl"
     allowedOrigins: []


### PR DESCRIPTION
Requested by Gemeente Utrecht.

Set Access-Control-Allow-Origin ```CORS_ALLOWED_HOSTS``` in nginx config.

Update static Set Access-Control-Allow-Origin according to openformulieren [readthedocs](https://open-forms.readthedocs.io/en/latest/developers/sdk/embedding.html?highlight=CORS#cross-origin-resource-sharing-cors)

