### PR TITLE
Updating to latest version of OIP

### DIFF
--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -3,7 +3,7 @@ name: openinwoner
 description: Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
 type: application
-version: 0.9.6
+version: 0.9.7
 appVersion: "1.7.1"
 
 dependencies:

--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -4,7 +4,7 @@ description: Platform voor gemeenten en overheden om producten inzichtelijker en
 
 type: application
 version: 0.9.6
-appVersion: "1.3"
+appVersion: "1.7.1"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
OIP AKS testomgeving draait zo te zien nog op een verouderde versie, poging van mijn kant om dit naar 1.7 te upgraden