### PR TITLE
Fix openinwoner nginx config to work with new version of openinwoner

### DIFF
--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -3,8 +3,8 @@ name: openinwoner
 description: Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
 type: application
-version: 0.9.9
-appVersion: "1.7.1"
+version: 1.0.0
+appVersion: "1.8.3"
 
 dependencies:
   - name: redis

--- a/charts/openinwoner/templates/configmap-nginx.yaml
+++ b/charts/openinwoner/templates/configmap-nginx.yaml
@@ -6,19 +6,18 @@ metadata:
     {{- include "openinwoner.nginxLabels" . | nindent 4 }}
 data:
   proxy: |
-    proxy_pass_header Server;
     proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $server_name;
+    proxy_set_header X-Scheme $scheme;
     proxy_connect_timeout 300s;
     proxy_read_timeout 300s;
+    proxy_set_header Host $http_host;
     proxy_redirect off;
     proxy_pass_request_headers on;
-    proxy_http_version 1.1;
+    add_header X-Cache-Status $upstream_cache_status;
     proxy_pass http://{{ include "openinwoner.fullname" . }}.{{ .Release.Namespace }};
-    {{- if .Values.settings.useXForwardedHost }}
-    proxy_set_header X-Forwarded-Host $http_host;
-    {{ else }}
-    proxy_set_header Host $http_host;
-    {{- end }}
 
   default.conf: |
     server {
@@ -66,8 +65,7 @@ data:
             return 200 'OK';
         }
 
-      location /private-media {
-          internal;
-          alias /app/private_media/;
+      location /media {
+          alias /app/media/;
       }
     }

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -166,7 +166,6 @@ extraVolumeMounts: []
 settings:
   allowedHosts: ""
   djangoSettingsModule: open_inwoner.conf.docker
-  useXForwardedHost: true
 
   # -- Will load all fixtures in /app/src/open_inwoner/conf/fixtures/*.json
   loadFixtures: false


### PR DESCRIPTION
- nginx config, proxy_headers to fix CSRF error when trying to log in to the /admin;
- Switch private_media to media;
- Update `appVersion` + `appVersion`; 

Tested, works.