### PR TITLE
:sparkles: Objecten 2.2.1 support oas file uploads

### DIFF
--- a/charts/objecten/Chart.yaml
+++ b/charts/objecten/Chart.yaml
@@ -3,5 +3,5 @@ name: objecten
 description: API om objecten te beheren die behoren bij een bepaald objecttype
 
 type: application
-version: 1.0.1
-appVersion: 2.1.1
+version: 1.1.0
+appVersion: 2.2.1

--- a/charts/objecten/README.md
+++ b/charts/objecten/README.md
@@ -1,6 +1,6 @@
 # objecten
 
-![Version: 0.9.9](https://img.shields.io/badge/Version-0.9.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
 
 API om objecten te beheren die behoren bij een bepaald objecttype
 
@@ -10,6 +10,7 @@ API om objecten te beheren die behoren bij een bepaald objecttype
 helm repo add my-repo https://maykinmedia.github.io/charts/
 helm install my-release my-repo/objecten
 ```
+
 
 ## Values
 
@@ -21,6 +22,10 @@ helm install my-release my-repo/objecten
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
+| azureVaultSecret.contentType | string | `""` |  |
+| azureVaultSecret.objectName | string | `""` |  |
+| azureVaultSecret.secretName | string | `"{{ .Values.existingSecret }}"` |  |
+| azureVaultSecret.vaultName | string | `nil` |  |
 | existingSecret | string | `nil` |  |
 | extraEnvVars | list | `[]` | Array with extra environment variables to add |
 | extraIngress | list | `[]` | Specify extra ingresses, for example if you have multiple ingress classes |
@@ -42,10 +47,41 @@ helm install my-release my-repo/objecten
 | livenessProbe.successThreshold | int | `1` |  |
 | livenessProbe.timeoutSeconds | int | `5` |  |
 | nameOverride | string | `""` |  |
+| nginx.autoscaling.enabled | bool | `false` |  |
+| nginx.config.clientMaxBodySize | string | `"10M"` |  |
+| nginx.existingConfigmap | string | `nil` |  |
+| nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
+| nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` |  |
+| nginx.image.tag | string | `"stable"` |  |
+| nginx.livenessProbe.failureThreshold | int | `3` |  |
+| nginx.livenessProbe.initialDelaySeconds | int | `60` |  |
+| nginx.livenessProbe.periodSeconds | int | `10` |  |
+| nginx.livenessProbe.successThreshold | int | `1` |  |
+| nginx.livenessProbe.timeoutSeconds | int | `5` |  |
+| nginx.podLabels | object | `{}` |  |
+| nginx.readinessProbe.failureThreshold | int | `3` |  |
+| nginx.readinessProbe.initialDelaySeconds | int | `30` |  |
+| nginx.readinessProbe.periodSeconds | int | `10` |  |
+| nginx.readinessProbe.successThreshold | int | `1` |  |
+| nginx.readinessProbe.timeoutSeconds | int | `5` |  |
+| nginx.replicaCount | int | `1` |  |
+| nginx.resources | object | `{}` |  |
+| nginx.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| nginx.securityContext.readOnlyRootFilesystem | bool | `false` |  |
+| nginx.securityContext.runAsNonRoot | bool | `true` |  |
+| nginx.securityContext.runAsUser | int | `101` |  |
+| nginx.service.annotations | object | `{}` |  |
+| nginx.service.port | int | `80` |  |
+| nginx.service.type | string | `"ClusterIP"` |  |
 | nodeSelector | object | `{}` |  |
 | pdb.create | bool | `false` |  |
 | pdb.maxUnavailable | string | `""` |  |
 | pdb.minAvailable | int | `1` |  |
+| persistence.enabled | bool | `true` |  |
+| persistence.existingClaim | string | `nil` |  |
+| persistence.mediaMountSubpath | string | `"objecten/media"` |  |
+| persistence.size | string | `"1Gi"` |  |
+| persistence.storageClassName | string | `""` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |

--- a/charts/objecten/templates/_helpers.tpl
+++ b/charts/objecten/templates/_helpers.tpl
@@ -68,6 +68,37 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create a name for NGINX
+We truncate at 57 chars in order to provide space for the "-nginx" suffix
+*/}}
+{{- define "objecten.nginxName" -}}
+{{ include "objecten.name" . | trunc 57 | trimSuffix "-" }}-nginx
+{{- end }}
+
+{{/*
+Create a default fully qualified name for NGINX.
+We truncate at 57 chars in order to provide space for the "-nginx" suffix
+*/}}
+{{- define "objecten.nginxFullname" -}}
+{{ include "objecten.fullname" . | trunc 57 | trimSuffix "-" }}-nginx
+{{- end }}
+
+{{/*
+NGINX labels
+*/}}
+{{- define "objecten.nginxLabels" -}}
+{{ include "objecten.commonLabels" . }}
+{{ include "objecten.nginxSelectorLabels" . }}
+{{- end }}
+
+{{/*
+NGINX selector labels
+*/}}
+{{- define "objecten.nginxSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "objecten.nginxFullname" . }}
+{{- end }}
+
+{{/*
 Ingress annotations
 */}}
 {{- define "objecten.ingress.annotations" -}}

--- a/charts/objecten/templates/configmap-nginx.yaml
+++ b/charts/objecten/templates/configmap-nginx.yaml
@@ -1,0 +1,74 @@
+{{- if not .Values.nginx.existingConfigmap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "objecten.nginxFullname" . }}
+  labels:
+  {{- include "objecten.nginxLabels" . | nindent 4 }}
+data:
+  proxy: |
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $server_name;
+    proxy_set_header X-Scheme $scheme;
+    proxy_connect_timeout 300s;
+    proxy_read_timeout 300s;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass_request_headers on;
+    add_header X-Cache-Status $upstream_cache_status;
+    proxy_pass http://{{ include "objecten.fullname" . }}.{{ .Release.Namespace }};
+
+  default.conf: |
+    server {
+      listen       8080 default_server;
+      server_name {{ .Values.settings.allowedHosts  | replace "," " "}} localhost;
+      server_tokens off;
+
+      gzip on;
+      gzip_http_version 1.0;
+      gzip_comp_level 2;
+      gzip_min_length 1100;
+      gzip_buffers 4 8k;
+      gzip_proxied any;
+      gzip_types
+        # text/html is always compressed by HttpGzipModule
+        text/css
+        text/javascript
+        text/xml
+        text/plain
+        text/x-component
+        application/javascript
+        application/json
+        application/xml
+        application/rss+xml
+        font/truetypenginc
+        font/opentype
+        application/vnd.ms-fontobject
+        image/svg+xml;
+      gzip_static on;
+      gzip_proxied  expired no-cache no-store private auth;
+      gzip_disable "MSIE [1-6]\.";
+      gzip_vary on;
+
+      add_header Feature-Policy "autoplay 'none'; camera 'none'" always;
+      add_header Referrer-Policy "same-origin";
+      add_header X-Content-Type-Options "nosniff";
+      add_header X-XSS-Protection "1; mode=block";
+
+      location / {
+          include conf.d/proxy;
+      }
+
+      location /_health/ {
+          access_log off;
+          error_log /var/log/nginx/error.log error;
+          return 200 'OK';
+      }
+
+      error_page  404              /404.html;
+      error_page  413              /413.json;
+      error_page  500 502 503 504  /500.json;
+    }
+{{- end }}

--- a/charts/objecten/templates/deployment.yaml
+++ b/charts/objecten/templates/deployment.yaml
@@ -70,10 +70,20 @@ spec:
           resources:
           {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            - name: media
+              mountPath: /app/media
+              subPath: {{ .Values.persistence.mediaMountSubpath  | default "objecten/media" }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "objecten.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
       volumes:
+        - name: media
+          persistentVolumeClaim:
+          {{- if .Values.persistence.enabled }}
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "objecten.fullname" . }}{{- end }}
+          {{- else }}
+          emptyDir: { }
+          {{- end }}
         {{- if .Values.extraVolumes }}
         {{- include "objecten.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
@@ -84,6 +94,84 @@ spec:
       {{- with .Values.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "objecten.nginxFullname" . }}
+  labels:
+    {{- include "objecten.nginxLabels" . | nindent 4 }}
+spec:
+  {{- if not .Values.nginx.autoscaling.enabled }}
+  replicas: {{ .Values.nginx.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "objecten.nginxSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-nginx: {{ include (print $.Template.BasePath "/configmap-nginx.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "objecten.nginxSelectorLabels" . | nindent 8 }}
+        {{- with .Values.nginx.podLabels }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "objecten.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: nginx
+          securityContext:
+            {{- toYaml .Values.nginx.securityContext | nindent 12 }}
+          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          livenessProbe:
+            httpGet:
+              path: /_health/
+              port: http
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            {{- toYaml .Values.nginx.resources | nindent 12 }}
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/
+            - name: media
+              mountPath: /app/media
+              subPath: {{ .Values.persistence.mediaMountSubpath  | default "objecten/media" }}
+      volumes:
+        - name: media
+          persistentVolumeClaim:
+          {{- if .Values.persistence.enabled }}
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "objecten.fullname" . }}{{- end }}
+          {{- else }}
+          emptyDir: { }
+          {{- end }}
+        - name: nginx-config
+          configMap:
+            name: {{ if .Values.nginx.existingConfigmap }}{{ .Values.nginx.existingConfigmap  }}{{- else }}{{ include "objecten.nginxFullname" . }}{{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/charts/objecten/templates/ingress.yaml
+++ b/charts/objecten/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "objecten.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $fullName := include "objecten.nginxFullname" . -}}
+{{- $svcPort := .Values.nginx.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}

--- a/charts/objecten/templates/pvc.yaml
+++ b/charts/objecten/templates/pvc.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "objecten.fullname" . }}
+  labels:
+    {{- include "objecten.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/objecten/templates/service.yaml
+++ b/charts/objecten/templates/service.yaml
@@ -13,3 +13,26 @@ spec:
       name: http
   selector:
     {{- include "objecten.selectorLabels" . | nindent 4 }}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "objecten.nginxFullname" . }}
+  labels:
+    {{- include "objecten.nginxLabels" . | nindent 4 }}
+  {{- with .Values.nginx.service.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }} : {{ tpl ($value | toString) $ }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.nginx.service.type }}
+  ports:
+    - port: {{ .Values.nginx.service.port }}
+      targetPort: 8080
+      name: http
+  selector:
+    {{- include "objecten.nginxSelectorLabels" . | nindent 4 }}

--- a/charts/objecten/values.yaml
+++ b/charts/objecten/values.yaml
@@ -115,6 +115,13 @@ tolerations: []
 
 affinity: {}
 
+persistence:
+  enabled: true
+  size: 1Gi
+  storageClassName: ""
+  existingClaim: null
+  mediaMountSubpath: objecten/media
+
 # Existing Secret must be defined for AzureVaultSecret to work
 existingSecret: null
 
@@ -203,3 +210,40 @@ settings:
     processes: ''
     maxRequests: ''
     harakiri: ''
+
+nginx:
+  image:
+    repository: nginxinc/nginx-unprivileged
+    pullPolicy: IfNotPresent
+    tag: stable
+  existingConfigmap: null
+  config:
+    clientMaxBodySize: 10M
+  service:
+    type: ClusterIP
+    port: 80
+    annotations: {}
+  replicaCount: 1
+  podLabels: {}
+  securityContext:
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    runAsUser: 101
+  autoscaling:
+    enabled: false
+  livenessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  resources: {}


### PR DESCRIPTION
zgw-consumers 2.0 allows OAS file uploads that are place on `/app/media`, so this needs a persistent volume.

Nginx pod so you can click the file without a 404.