### PR TITLE
Modify openinwoner configmap-nginx to use https for x-forwarded-proto

### DIFF
--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -3,7 +3,7 @@ name: openinwoner
 description: Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: "1.13.1"
 
 dependencies:

--- a/charts/openinwoner/templates/configmap-nginx.yaml
+++ b/charts/openinwoner/templates/configmap-nginx.yaml
@@ -8,7 +8,6 @@ data:
   proxy: |
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Host $server_name;
     proxy_set_header X-Scheme $scheme;
     proxy_connect_timeout 300s;


### PR DESCRIPTION
Taiga dimpact 68

Django applications listen to HTTP_X_FORWARDED_PROTO if provided, otherwise Django falls back on 'https' by default.

nginx however now uses $scheme which in the chart is http instead of https, as such Django things it's not behind https.

Removing this line ensures openinwoner works the same as openformulieren, making use of the 'https' default