### PR TITLE
Add cronjob to clean openforms logs

### DIFF
--- a/charts/openforms/Chart.yaml
+++ b/charts/openforms/Chart.yaml
@@ -3,8 +3,8 @@ name: openforms
 description: Snel en eenvoudig slimme formulieren bouwen en publiceren
 
 type: application
-version: 1.4.2
-appVersion: 2.7.4
+version: 1.4.3
+appVersion: 2.7.8
 icon: https://open-forms.readthedocs.io/en/stable/_static/logo.svg
 
 dependencies:

--- a/charts/openforms/README.md
+++ b/charts/openforms/README.md
@@ -1,6 +1,6 @@
 # openforms
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.4](https://img.shields.io/badge/AppVersion-2.7.4-informational?style=flat-square)
+![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.8](https://img.shields.io/badge/AppVersion-2.7.8-informational?style=flat-square)
 
 Snel en eenvoudig slimme formulieren bouwen en publiceren
 
@@ -154,6 +154,11 @@ helm install my-release my-repo/openforms
 | settings.celery.brokerUrl | string | `""` |  |
 | settings.celery.logLevel | string | `"debug"` |  |
 | settings.celery.resultBackend | string | `""` |  |
+| settings.cleanLogs.cronjob.historyLimit | int | `1` |  |
+| settings.cleanLogs.cronjob.resources | object | `{}` |  |
+| settings.cleanLogs.cronjob.schedule | string | `"0 0 * * *"` | Schedule to run the clean logs cronjob |
+| settings.cleanLogs.daysRetained | int | `90` | Number of days to retain logs |
+| settings.cleanLogs.enabled | bool | `true` | Clean Logs, Messages, Timelog Entries |
 | settings.cookieSamesite | string | `""` | Choises Strict or Lax |
 | settings.cors.allowAllOrigins | bool | `false` |  |
 | settings.cors.allowedOrigins | list | `[]` |  |

--- a/charts/openforms/templates/clean-script.yaml
+++ b/charts/openforms/templates/clean-script.yaml
@@ -1,0 +1,74 @@
+{{ if .Values.settings.cleanLogs.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+metadata:
+  name: {{ include "openforms.fullname" . }}-clean-logs
+  labels:
+    {{- include "openforms.labels" . | nindent 4 }}
+data:
+  clean_logs.py: |-
+    from datetime import timedelta
+
+    from django.utils import timezone
+    from django_yubin.models import Message
+    from timeline_logger.models import TimelineLog
+
+    DAYS = {{ .Values.settings.cleanLogs.daysRetained }}
+
+    period = timedelta(weeks=DAYS // 7)
+    limit_datetime = timezone.now() - period
+
+    # Deleting the logs one day at a time, going backwards in time
+    total_logs = TimelineLog.objects.filter(timestamp__lt=limit_datetime).count()
+
+    print(f"\nTotal number of logs to delete: {total_logs}\n")
+
+    current_datetime = limit_datetime
+    previous_timestamp = current_datetime - timedelta(days=1)
+
+    deleted_logs_count = 0
+    while TimelineLog.objects.filter(timestamp__lt=limit_datetime).exists():
+        logs_to_delete = TimelineLog.objects.filter(
+            timestamp__gte=previous_timestamp, timestamp__lt=current_datetime
+        )
+        count = logs_to_delete.count()
+        deleted_logs_count += count
+
+        logs_to_delete.delete()
+
+        print(
+            f"Deleted {count} logs (from {previous_timestamp} to {current_datetime}). "
+            f"Progress: {deleted_logs_count} / {total_logs}"
+        )
+
+        current_datetime = previous_timestamp
+        previous_timestamp = current_datetime - timedelta(days=1)
+
+    # Deleting the messages one day at a time, going backwards in time
+    total_messages = Message.objects.filter(date_created__lt=limit_datetime).count()
+
+    print(f"\nTotal number of messages to delete: {total_messages}\n")
+
+    current_datetime = limit_datetime
+    previous_timestamp = current_datetime - timedelta(days=1)
+
+    deleted_messages = 0
+    while Message.objects.filter(date_created__lt=limit_datetime).exists():
+        messages_to_delete = Message.objects.filter(
+            date_created__gte=previous_timestamp, date_created__lt=current_datetime
+        )
+
+        count = messages_to_delete.count()
+        deleted_messages += count
+
+        messages_to_delete.delete()
+
+        print(
+            f"Deleted {count} messages (from {previous_timestamp} to {current_datetime}). "
+            f"Progress: {deleted_messages} / {total_messages}"
+        )
+
+        current_datetime = previous_timestamp
+        previous_timestamp = current_datetime - timedelta(days=1)
+{{- end }}        

--- a/charts/openforms/templates/cronjob-clean-logs.yaml
+++ b/charts/openforms/templates/cronjob-clean-logs.yaml
@@ -52,25 +52,37 @@ spec:
               command:
                 - "/bin/bash"
                 - "-c"
-                # - /usr/bin/sleep 10000
+
                 -  /app/src/manage.py shell < /app/scripts/clean_logs.py
               volumeMounts:
+                - name: media
+                  mountPath: /app/private_media
+                  subPath: {{ .Values.persistence.privateMediaMountSubpath | default "openforms/private_media" }}
+                - name: media
+                  mountPath: /app/media
+                  subPath: {{ .Values.persistence.mediaMountSubpath  | default "openforms/media" }}
+                - name: clean-logs
+                  mountPath: /app/scripts/
+                  readOnly: true                  
                 {{- if .Values.extraVolumeMounts }}
                 {{- include "openforms.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $ ) | nindent 16 }}
                 {{- end }}
-                - name: clean-logs
-                  mountPath: /app/scripts/
-                  readOnly: true
           volumes:
-            {{- if .Values.extraVolumes }}
-            {{- include "openforms.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 12 }}
-            {{- end }}
+            - name: media
+              persistentVolumeClaim:
+              {{- if .Values.persistence.enabled }}
+                claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "openforms.fullname" . }}{{- end }}
+              {{- else }}
+              emptyDir: { }
+              {{- end }}
             - name: clean-logs
               configMap:
                 name: {{ include "openforms.fullname" . }}-clean-logs
-                defaultMode: 0755                      
+                defaultMode: 0755              
+            {{- if .Values.extraVolumes }}
+            {{- include "openforms.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 12 }}
+            {{- end }}
           {{- with .Values.nodeSelector }}
-
           nodeSelector:
           {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/openforms/templates/cronjob-clean-logs.yaml
+++ b/charts/openforms/templates/cronjob-clean-logs.yaml
@@ -1,0 +1,85 @@
+{{ if .Values.settings.cleanLogs.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "openforms.fullname" . }}-clean-logs
+  labels:
+    {{- include "openforms.commonLabels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.settings.cleanLogs.cronjob.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.settings.cleanLogs.cronjob.historyLimit }}
+  failedJobsHistoryLimit: {{ .Values.settings.cleanLogs.cronjob.historyLimit }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+          {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "openforms.commonLabels" . | nindent 12 }}
+            {{- with .Values.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "openforms.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          restartPolicy: OnFailure
+          containers:
+            - name: {{ .Chart.Name }}
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 16 }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              envFrom:
+                - secretRef:
+                    name: {{ .Values.existingSecret | default (include "openforms.fullname" .) }}
+                - configMapRef:
+                    name: {{ include "openforms.fullname" . }}
+              env:
+                {{- if .Values.extraEnvVars }}
+                {{- include "openforms.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 16 }}
+                {{- end }}
+              resources:
+              {{- toYaml .Values.settings.cleanLogs.cronjob.resources | nindent 16 }}
+              command:
+                - "/bin/bash"
+                - "-c"
+                # - /usr/bin/sleep 10000
+                -  /app/src/manage.py shell < /app/scripts/clean_logs.py
+              volumeMounts:
+                {{- if .Values.extraVolumeMounts }}
+                {{- include "openforms.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $ ) | nindent 16 }}
+                {{- end }}
+                - name: clean-logs
+                  mountPath: /app/scripts/
+                  readOnly: true
+          volumes:
+            {{- if .Values.extraVolumes }}
+            {{- include "openforms.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 12 }}
+            {{- end }}
+            - name: clean-logs
+              configMap:
+                name: {{ include "openforms.fullname" . }}-clean-logs
+                defaultMode: 0755                      
+          {{- with .Values.nodeSelector }}
+
+          nodeSelector:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/openforms/values.yaml
+++ b/charts/openforms/values.yaml
@@ -186,6 +186,17 @@ settings:
   useXForwardedHost: false
   escapeRegistrationOutput: false
 
+  cleanLogs:
+    # -- Clean Logs, Messages, Timelog Entries
+    enabled: true
+    # -- Number of days to retain logs
+    daysRetained: 90
+    cronjob:
+      # -- Schedule to run the clean logs cronjob
+      schedule: "0 0 * * *"
+      historyLimit: 1
+      resources: {}
+
   # -- Generate secret key at https://djecrety.ir/
   secretKey: ""
 


### PR DESCRIPTION
Add clean logs script (Message and TimelineLog) and cronjob to clean logs in openforms.

```
~$ k get pods
NAME                                  READY   STATUS      RESTARTS      AGE
openforms-776fc4f678-5cbll            1/1     Running     2 (24m ago)   31m
openforms-beat-76ff6c95f6-g6vjz       1/1     Running     0             31m
openforms-clean-logs-28796274-r4pb6   0/1     Completed   0             34s
openforms-flower-5dfc448d7f-msbz4     1/1     Running     0             31m
openforms-nginx-b756d8f45-bgmtr       1/1     Running     0             31m
openforms-redis-master-0              1/1     Running     0             31m
openforms-worker-75f7c6cc59-7h8mm     1/1     Running     0             31m
openforms-worker-75f7c6cc59-zlt8c     1/1     Running     0             31m
(ansible) sjoerd@mint-laptop:~$ k logs openforms-clean-logs-28796274-r4pb6

Total number of logs to delete: 0


Total number of messages to delete: 0

```