### PR TITLE
:bookmark: Openforms helm 1.5.0

### DIFF
--- a/charts/openforms/Chart.yaml
+++ b/charts/openforms/Chart.yaml
@@ -3,8 +3,8 @@ name: openforms
 description: Snel en eenvoudig slimme formulieren bouwen en publiceren
 
 type: application
-version: 1.4.4
-appVersion: 2.7.8
+version: 1.5.0
+appVersion: 2.8.1
 icon: https://open-forms.readthedocs.io/en/stable/_static/logo.svg
 
 dependencies:

--- a/charts/openforms/README.md
+++ b/charts/openforms/README.md
@@ -1,15 +1,8 @@
 # openforms
 
-![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.8](https://img.shields.io/badge/AppVersion-2.7.8-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.1](https://img.shields.io/badge/AppVersion-2.8.1-informational?style=flat-square)
 
 Snel en eenvoudig slimme formulieren bouwen en publiceren
-
-## TL;DR
-
-```console
-helm repo add my-repo https://maykinmedia.github.io/charts/
-helm install my-release my-repo/openforms
-```
 
 ## Requirements
 
@@ -184,6 +177,9 @@ helm install my-release my-repo/openforms
 | settings.email.useTLS | bool | `false` |  |
 | settings.email.username | string | `""` |  |
 | settings.environment | string | `nil` |  |
+| settings.environmentLabelBackgroundColor | string | `""` | CSS color value for the environment information background color. Defaults to orange, example values can be specified in HEX format too, e.g.: #FF0000 for red. |
+| settings.environmentLabelForegroundColor | string | `""` | CSS color value for the environment information text color. Defaults to black. Follows the same rules as ENVIRONMENT_BACKGROUND_COLOR. |
+| settings.environmentLabelName | string | `""` | Environment information to display, defaults to the value of ENVIRONMENT. Only displayed when SHOW_ENVIRONMENT is set to True. You can set this to strings like OpenGem PROD or simply PROD, depending on your needs. |
 | settings.escapeRegistrationOutput | bool | `false` |  |
 | settings.flower.basicAuth | string | `""` |  |
 | settings.flower.urlPrefix | string | `""` |  |
@@ -194,6 +190,7 @@ helm install my-release my-repo/openforms
 | settings.oidc | object | `{"useLegacyDigidEndpoint":false,"useLegacyEndpont":false,"useLegacyOrgEndpoint":false}` | https://open-forms.readthedocs.io/en/latest/changelog.html#upgrade-notes |
 | settings.secretKey | string | `""` | Generate secret key at https://djecrety.ir/ |
 | settings.sentry.dsn | string | `""` |  |
+| settings.showLabelEnvironment | string | `"false"` | Display environment information in the header in the admin. Defaults to True. Environment information is only displayed to logged in users. |
 | settings.throttling.enable | bool | `true` |  |
 | settings.throttling.rateAnonymous | string | `""` |  |
 | settings.throttling.ratePolling | string | `""` |  |

--- a/charts/openforms/README.md
+++ b/charts/openforms/README.md
@@ -24,18 +24,7 @@ Snel en eenvoudig slimme formulieren bouwen en publiceren
 | azureVaultSecret.objectName | string | `""` |  |
 | azureVaultSecret.secretName | string | `"{{ .Values.existingSecret }}"` |  |
 | azureVaultSecret.vaultName | string | `nil` |  |
-| beat.enabled | bool | `true` |  |
-| beat.livenessProbe.failureThreshold | int | `6` |  |
-| beat.livenessProbe.initialDelaySeconds | int | `60` |  |
-| beat.livenessProbe.periodSeconds | int | `10` |  |
-| beat.livenessProbe.successThreshold | int | `1` |  |
-| beat.livenessProbe.timeoutSeconds | int | `5` |  |
 | beat.podLabels | object | `{}` |  |
-| beat.readinessProbe.failureThreshold | int | `6` |  |
-| beat.readinessProbe.initialDelaySeconds | int | `30` |  |
-| beat.readinessProbe.periodSeconds | int | `10` |  |
-| beat.readinessProbe.successThreshold | int | `1` |  |
-| beat.readinessProbe.timeoutSeconds | int | `5` |  |
 | beat.replicaCount | int | `1` |  |
 | beat.resources | object | `{}` |  |
 | existingSecret | string | `nil` |  |
@@ -190,7 +179,7 @@ Snel en eenvoudig slimme formulieren bouwen en publiceren
 | settings.oidc | object | `{"useLegacyDigidEndpoint":false,"useLegacyEndpont":false,"useLegacyOrgEndpoint":false}` | https://open-forms.readthedocs.io/en/latest/changelog.html#upgrade-notes |
 | settings.secretKey | string | `""` | Generate secret key at https://djecrety.ir/ |
 | settings.sentry.dsn | string | `""` |  |
-| settings.showLabelEnvironment | string | `"false"` | Display environment information in the header in the admin. Defaults to True. Environment information is only displayed to logged in users. |
+| settings.showLabelEnvironment | bool | `false` | Display environment information in the header in the admin. Defaults to True. Environment information is only displayed to logged in users. |
 | settings.throttling.enable | bool | `true` |  |
 | settings.throttling.rateAnonymous | string | `""` |  |
 | settings.throttling.ratePolling | string | `""` |  |

--- a/charts/openforms/templates/configmap.yaml
+++ b/charts/openforms/templates/configmap.yaml
@@ -103,3 +103,13 @@ data:
   USE_LEGACY_OIDC_ENDPOINTS: {{ if .Values.settings.oidc.useLegacyEndpont }}"True"{{ else }}"False"{{ end }}
   USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS: {{ if .Values.settings.oidc.useLegacyDigidEndpoint }}"True"{{ else }}"False"{{ end }}
   USE_LEGACY_ORG_OIDC_ENDPOINTS: {{ if .Values.settings.oidc.useLegacyOrgEndpoint }}"True"{{ else }}"False"{{ end }}
+  SHOW_ENVIRONMENT: {{ if .Values.settings.showLabelEnvironment }}"True"{{ else }}"False"{{ end }}
+  {{- if .Values.settings.environmentLabelName }}
+  ENVIRONMENT_LABEL: {{ .Values.settings.environmentLabelName | toString | quote }}
+  {{- end }}
+  {{- if .Values.settings.environmentLabelBackgroundColor }}
+  ENVIRONMENT_BACKGROUND_COLOR: {{ .Values.settings.environmentLabelBackgroundColor | toString | quote }}
+  {{- end }}
+  {{- if .Values.settings.environmentLabelForegroundColor }}
+  ENVIRONMENT_FOREGROUND_COLOR: {{ .Values.settings.environmentLabelForegroundColor | toString | quote }}
+  {{- end }}

--- a/charts/openforms/values.yaml
+++ b/charts/openforms/values.yaml
@@ -396,18 +396,6 @@ flower:
 beat:
   replicaCount: 1
   podLabels: {}
-  livenessProbe:
-    initialDelaySeconds: 60
-    periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 6
-    successThreshold: 1
-  readinessProbe:
-    initialDelaySeconds: 30
-    periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 6
-    successThreshold: 1
   resources: {}
 
 ##################

--- a/charts/openforms/values.yaml
+++ b/charts/openforms/values.yaml
@@ -205,6 +205,15 @@ settings:
 
   environment: null
 
+  # -- Display environment information in the header in the admin. Defaults to True. Environment information is only displayed to logged in users.
+  showLabelEnvironment: false
+  # -- Environment information to display, defaults to the value of ENVIRONMENT. Only displayed when SHOW_ENVIRONMENT is set to True. You can set this to strings like OpenGem PROD or simply PROD, depending on your needs.
+  environmentLabelName: ""
+  # --  CSS color value for the environment information background color. Defaults to orange, example values can be specified in HEX format too, e.g.: #FF0000 for red.
+  environmentLabelBackgroundColor: ""
+  # -- CSS color value for the environment information text color. Defaults to black. Follows the same rules as ENVIRONMENT_BACKGROUND_COLOR.
+  environmentLabelForegroundColor: ""
+
   cors:
     # if defining the cors hosts, always include the own URL!
     allowAllOrigins: false
@@ -385,7 +394,6 @@ flower:
   resources: {}
 
 beat:
-  enabled: true
   replicaCount: 1
   podLabels: {}
   livenessProbe:


### PR DESCRIPTION
- Support new `SHOW_ENVIRONMENT` label environment variables. By default these will NOT be enabled, overriding application defaults. See https://open-forms.readthedocs.io/en/latest/installation/config.html#other-settings for more information.
- :fire: remove unused beat values (it has no health probes, nor can it be disabled)

Note, this chart will work with older openforms versions (e.g 7.x), the new environment variables will take no effect.