### PR TITLE
search_index --rebuild  init container

### DIFF
--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -3,7 +3,7 @@ name: openinwoner
 description: Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
 type: application
-version: 1.5.3
+version: 1.5.4
 appVersion: "1.21.3"
 icon: https://docs.openinwoner.nl/en/latest/_static/logo.png
 

--- a/charts/openinwoner/README.md
+++ b/charts/openinwoner/README.md
@@ -1,6 +1,6 @@
 # openinwoner
 
-![Version: 1.5.3](https://img.shields.io/badge/Version-1.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.21.3](https://img.shields.io/badge/AppVersion-1.21.3-informational?style=flat-square)
+![Version: 1.5.4](https://img.shields.io/badge/Version-1.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.21.3](https://img.shields.io/badge/AppVersion-1.21.3-informational?style=flat-square)
 
 Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
@@ -169,6 +169,7 @@ helm install my-release my-repo/openinwoner
 | settings.environment | string | `nil` |  |
 | settings.isHttps | bool | `true` |  |
 | settings.loadFixtures | bool | `false` | Will load all fixtures in /app/src/open_inwoner/conf/fixtures/*.json |
+| settings.searchInexInitContainer | bool | `false` |  |
 | settings.secretKey | string | `""` | Generate secret key at https://djecrety.ir/ |
 | settings.sentry.dsn | string | `""` |  |
 | settings.smsgateway.apikey | string | `""` |  |

--- a/charts/openinwoner/templates/deployment.yaml
+++ b/charts/openinwoner/templates/deployment.yaml
@@ -32,6 +32,41 @@ spec:
       serviceAccountName: {{ include "openinwoner.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.settings.searchInexInitContainer }}
+      initContainers:
+        - name: {{ .Chart.Name }}-search-index
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 16 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.existingSecret | default (include "openinwoner.fullname" .) }}
+            - configMapRef:
+                name: {{ include "openinwoner.fullname" . }}
+          env:
+            {{- if .Values.extraEnvVars }}
+            {{- include "openinwoner.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 16 }}
+            {{- end }}
+          command:
+            - "/bin/bash"
+            - "-c"
+          args:
+          - |
+            /wait_for_db.sh
+            /app/src/manage.py migrate
+            /app/src/manage.py search_index --rebuild -f
+          volumeMounts:
+            - name: media
+              mountPath: /app/private-media
+              subPath: {{ .Values.persistence.privateMediaMountSubpath | default "openinwoner/private_media" }}
+            - name: media
+              mountPath: /app/media
+              subPath: {{ .Values.persistence.mediaMountSubpath  | default "openinwoner/media" }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "openinwoner.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $ ) | nindent 12 }}
+            {{- end }}
+        {{- end }}        
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -250,6 +250,9 @@ settings:
     maxRequests: ""
     harakiri: ""
 
+  # -- Runs a init container that will run /app/src/manage.py search_index --rebuild -f. You might want to enable this one time for new deployments if you want to prevent 500 errors when using the search function
+  searchInexInitContainer: false
+
 worker:
   replicaCount: 1
   concurrency: 4


### PR DESCRIPTION
Feature to run `/app/src/manage.py search_index --rebuild -f` with an init container. This command is run with celery during night time. So new deployments will not have the Elasticsearch indexes and the search feature will cause an 500 error.

Running the initcontainer on new deployments will prevent this.
