### PR TITLE
Objecten 2.5.1 - :pencil2: values

### DIFF
--- a/charts/objecten/Chart.yaml
+++ b/charts/objecten/Chart.yaml
@@ -3,7 +3,7 @@ name: objecten
 description: API om objecten te beheren die behoren bij een bepaald objecttype
 
 type: application
-version: 2.5.0
+version: 2.5.1
 appVersion: 2.4.4
 
 dependencies:

--- a/charts/objecten/values.yaml
+++ b/charts/objecten/values.yaml
@@ -16,11 +16,11 @@ configuration:
     domain: ""
     organization: ""
   objectTypes:
-    enable: false
+    enabled: false
     ApiRoot: ""
     token: ""
   demo:
-    enable: false
+    enabled: false
     token:
     person:
     email: 
@@ -34,14 +34,13 @@ configuration:
     enabled: true
   job:
     # -- Run the setup configuration command as a job
-    enabled: true
+    enabled: false
     backoffLimit: 6
     # -- 0 Will clean the job after it is finished
     ttlSecondsAfterFinished: 0    
     restartPolicy: OnFailure
     # Note, this field is immutable
     resources: {}
-
       # limits:
       #   cpu: 200m
       #   memory: 256Mi


### PR DESCRIPTION
Typo in values configuration `enable` -> `enabled` and do not use job by default.