### PR TITLE
:sparkles: [open-zaak/open-notificaties#240] Expose `result_expires` Celery setting via envvar

### DIFF
--- a/charts/opennotificaties/CHANGELOG.md
+++ b/charts/opennotificaties/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.0 (2025-05-08)
+
+- [open-zaak/open-notificaties#240] Expose `result_expires` Celery setting via envvar
+
 ## 1.8.4 (2025-05-14)
 
 - Fixed missing environment variable `NOTIFICATION_REQUESTS_TIMEOUT`.

--- a/charts/opennotificaties/Chart.yaml
+++ b/charts/opennotificaties/Chart.yaml
@@ -3,8 +3,8 @@ name: opennotificaties
 description: API voor het routeren van notificaties
 
 type: application
-version: 1.8.4
-appVersion: 1.8.0
+version: 1.9.0
+appVersion: 1.9.0
 
 dependencies:
   - name: redis

--- a/charts/opennotificaties/README.md
+++ b/charts/opennotificaties/README.md
@@ -1,6 +1,6 @@
 # opennotificaties
 
-![Version: 1.8.4](https://img.shields.io/badge/Version-1.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.0](https://img.shields.io/badge/AppVersion-1.9.0-informational?style=flat-square)
 
 API voor het routeren van notificaties
 
@@ -147,6 +147,7 @@ API voor het routeren van notificaties
 | settings.celery.publishBrokerUrl | string | `""` | Sets the 'PUBLISHER_BROKER_URL' var, only required when tags.rabbitmq is false |
 | settings.celery.rabbitmqHost | string | `""` | RabbitMQ server hostname |
 | settings.celery.resultBackend | string | `""` | Sets the 'CELERY_RESULT_BACKEND' var, only required when tags.redis is false |
+| settings.celery.resultExpires | int | `3600` | Sets the 'CELERY_RESULT_EXPIRES' var |
 | settings.cleanOldNotifications.cronjob.historyLimit | int | `1` |  |
 | settings.cleanOldNotifications.cronjob.resources | object | `{}` |  |
 | settings.cleanOldNotifications.cronjob.schedule | string | `"0 0 * * *"` | Schedule to run the clean logged notifications cronjob |

--- a/charts/opennotificaties/templates/configmap.yaml
+++ b/charts/opennotificaties/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
   {{- end }}
   CELERY_LOGLEVEL:  {{ .Values.settings.celery.logLevel | upper | toString | quote }}
   CELERY_WORKER_CONCURRENCY: {{ .Values.worker.concurrency | toString | quote }}
+  CELERY_RESULT_EXPIRES: {{ .Values.settings.celery.resultExpires | toString | quote }}
   {{ if .Values.worker.maxWorkerLivenessDelta }}
   MAX_WORKER_LIVENESS_DELTA: {{ .Values.worker.maxWorkerLivenessDelta | toString | quote }}
   {{- end }}    

--- a/charts/opennotificaties/values.yaml
+++ b/charts/opennotificaties/values.yaml
@@ -413,6 +413,8 @@ settings:
     logLevel: debug
     # -- Sets the 'CELERY_BROKER_URL' var, only required when tags.rabbitmq is false
     brokerUrl: ""
+    # -- Sets the 'CELERY_RESULT_EXPIRES' var
+    resultExpires: 3600
     # -- Sets the 'CELERY_RESULT_BACKEND' var, only required when tags.redis is false
     resultBackend: ""
     # -- Sets the 'PUBLISHER_BROKER_URL' var, only required when tags.rabbitmq is false


### PR DESCRIPTION
Fixes  [open-zaak/open-notificaties#240]

Related open-notificaties PR https://github.com/open-zaak/open-notificaties/pull/266