### PR TITLE
Adding project.chart label, referenced in project.labels

### DIFF
--- a/charts/maykin-utils-lib/CHANGELOG.md
+++ b/charts/maykin-utils-lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## 0.2.1 (2025-04-21)
+
+- Adding label in helpers.tpl for a Chart, `project.chart`. Example usage: *helm.sh/chart: openproduct-0.1.0*
+
+
 ## 0.2.0 (2025-01-28)
 
 - [#172] Add templates for the HPAs for the webapp, the worker and nginx.

--- a/charts/maykin-utils-lib/Chart.yaml
+++ b/charts/maykin-utils-lib/Chart.yaml
@@ -3,5 +3,5 @@ name: maykin-utils-lib
 description: A Library Helm chart containing code shared between Maykin helm charts
 
 type: library
-version: 0.2.0
+version: 0.2.1
 

--- a/charts/maykin-utils-lib/templates/_helpers.tpl
+++ b/charts/maykin-utils-lib/templates/_helpers.tpl
@@ -7,9 +7,8 @@
 {{- end }}
 
 {{- define "project.chart" -}}
-{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
-
 
 {{/*
 Create a default fully qualified app name.

--- a/charts/maykin-utils-lib/templates/_helpers.tpl
+++ b/charts/maykin-utils-lib/templates/_helpers.tpl
@@ -6,6 +6,11 @@
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "project.chart" -}}
+{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).


### PR DESCRIPTION
* Small correction/addition. 
The project.chart is used in project.lables which is used in the current hpa libraries. 