### PR TITLE
Add extra volumes and volumemounts for nginx

### DIFF
--- a/charts/openarchiefbeheer/CHANGELOG.md
+++ b/charts/openarchiefbeheer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.11 (2025-06-11)
+
+- Add extra volumes and volumemounts for nginx so it can be deployed with readOnlyRootFilesystem: true
+
 ## 1.3.10 (2025-05-22)
 
 - Change the default nginx port number to 80 in values.yaml. (To be in line with the rest of Maykin apps)

--- a/charts/openarchiefbeheer/Chart.yaml
+++ b/charts/openarchiefbeheer/Chart.yaml
@@ -3,7 +3,7 @@ name: openarchiefbeheer
 description: Opstellen, beheren en uitvoeren van vernietigingslijsten, voor gebruik met Zaakgericht werken
 
 type: application
-version: 1.3.10
+version: 1.3.11
 appVersion: 1.0.0
 
 dependencies:

--- a/charts/openarchiefbeheer/README.md
+++ b/charts/openarchiefbeheer/README.md
@@ -1,6 +1,6 @@
 # openarchiefbeheer
 
-![Version: 1.3.10](https://img.shields.io/badge/Version-1.3.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.3.11](https://img.shields.io/badge/Version-1.3.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Opstellen, beheren en uitvoeren van vernietigingslijsten, voor gebruik met Zaakgericht werken
 
@@ -74,6 +74,8 @@ Opstellen, beheren en uitvoeren van vernietigingslijsten, voor gebruik met Zaakg
 | nameOverride | string | `""` |  |
 | nginx.autoscaling.enabled | bool | `false` |  |
 | nginx.existingConfigmap | string | `nil` |  |
+| nginx.extraVolumeMounts | list | `[]` |  |
+| nginx.extraVolumes | list | `[]` |  |
 | nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
 | nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` |  |
 | nginx.image.tag | string | `"stable"` |  |

--- a/charts/openarchiefbeheer/templates/deployment.yaml
+++ b/charts/openarchiefbeheer/templates/deployment.yaml
@@ -200,6 +200,9 @@ spec:
             - name: media
               mountPath: /app/media
               subPath: {{ .Values.persistence.mediaMountSubpath  | default "openarchiefbeheer/media" }}
+            {{- if .Values.nginx.extraVolumeMounts }}
+            {{- include "openarchiefbeheer.tplvalues.render" ( dict "value" .Values.nginx.extraVolumeMounts "context" $ ) | nindent 12 }}
+            {{- end }}
       volumes:
         - name: media
           {{- if .Values.persistence.enabled }}
@@ -211,6 +214,9 @@ spec:
         - name: nginx-config
           configMap:
             name: {{ if .Values.nginx.existingConfigmap }}{{ .Values.nginx.existingConfigmap  }}{{- else }}{{ include "openarchiefbeheer.nginxFullname" . }}{{- end }}
+        {{- if .Values.nginx.extraVolumes }}
+        {{- include "openarchiefbeheer.tplvalues.render" ( dict "value" .Values.nginx.extraVolumes "context" $ ) | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openarchiefbeheer/values.yaml
+++ b/charts/openarchiefbeheer/values.yaml
@@ -304,6 +304,19 @@ nginx:
     pullPolicy: IfNotPresent
     tag: stable
   existingConfigmap: null
+  # extraVolumes Optionally specify extra list of additional volumes
+  # e.g:
+  # extraVolumes:
+  #   - name: tmp
+  #     emptyDir: {}
+  #
+  extraVolumes: []
+  # extraVolumeMounts Optionally specify extra list of additional volumeMounts
+  # e.g:
+  # extraVolumeMounts:
+  #   - name: tmp
+  #     mountPath: /tmp
+  extraVolumeMounts: []
   service:
     type: ClusterIP
     port: 80

--- a/charts/openforms/CHANGELOG.md
+++ b/charts/openforms/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.5 (2025-06-11)
+
+- Add extra volumes and volumemounts for nginx so it can be deployed with readOnlyRootFilesystem: true
+
 ## 1.8.4 (2025-04-25)
 - [#193] Fix missing dependency on bitnami common
 

--- a/charts/openforms/Chart.yaml
+++ b/charts/openforms/Chart.yaml
@@ -3,7 +3,7 @@ name: openforms
 description: Snel en eenvoudig slimme formulieren bouwen en publiceren
 
 type: application
-version: 1.8.4
+version: 1.8.5
 appVersion: 3.0.1
 icon: https://open-forms.readthedocs.io/en/stable/_static/logo.svg
 

--- a/charts/openforms/README.md
+++ b/charts/openforms/README.md
@@ -1,6 +1,6 @@
 # openforms
 
-![Version: 1.8.4](https://img.shields.io/badge/Version-1.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.1](https://img.shields.io/badge/AppVersion-3.0.1-informational?style=flat-square)
+![Version: 1.8.5](https://img.shields.io/badge/Version-1.8.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.1](https://img.shields.io/badge/AppVersion-3.0.1-informational?style=flat-square)
 
 Snel en eenvoudig slimme formulieren bouwen en publiceren
 
@@ -85,6 +85,8 @@ Snel en eenvoudig slimme formulieren bouwen en publiceren
 | nginx.autoscaling.enabled | bool | `false` |  |
 | nginx.config.clientMaxBodySize | string | `"10M"` |  |
 | nginx.existingConfigmap | string | `nil` |  |
+| nginx.extraVolumeMounts | list | `[]` |  |
+| nginx.extraVolumes | list | `[]` |  |
 | nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
 | nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` |  |
 | nginx.image.tag | string | `"stable"` |  |

--- a/charts/openforms/templates/deployment.yaml
+++ b/charts/openforms/templates/deployment.yaml
@@ -392,6 +392,9 @@ spec:
             - name: media
               mountPath: /app/media
               subPath: {{ .Values.persistence.mediaMountSubpath  | default "openforms/media" }}
+            {{- if .Values.nginx.extraVolumeMounts }}
+            {{- include "openforms.tplvalues.render" ( dict "value" .Values.nginx.extraVolumeMounts "context" $ ) | nindent 12 }}
+            {{- end }}
       volumes:
         - name: media
           persistentVolumeClaim:
@@ -403,6 +406,9 @@ spec:
         - name: nginx-config
           configMap:
             name: {{ if .Values.nginx.existingConfigmap }}{{ .Values.nginx.existingConfigmap  }}{{- else }}{{ include "openforms.nginxFullname" . }}{{- end }}
+        {{- if .Values.nginx.extraVolumes }}
+        {{- include "openforms.tplvalues.render" ( dict "value" .Values.nginx.extraVolumes "context" $ ) | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openforms/values.yaml
+++ b/charts/openforms/values.yaml
@@ -495,6 +495,19 @@ nginx:
     pullPolicy: IfNotPresent
     tag: stable
   existingConfigmap: null
+  # extraVolumes Optionally specify extra list of additional volumes
+  # e.g:
+  # extraVolumes:
+  #   - name: tmp
+  #     emptyDir: {}
+  #
+  extraVolumes: []
+  # extraVolumeMounts Optionally specify extra list of additional volumeMounts
+  # e.g:
+  # extraVolumeMounts:
+  #   - name: tmp
+  #     mountPath: /tmp
+  extraVolumeMounts: []
   config:
     clientMaxBodySize: 10M
   service:

--- a/charts/openinwoner/CHANGELOG.md
+++ b/charts/openinwoner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.4 (2025-06-11)
+
+- Add extra volumes and volumemounts for nginx so it can be deployed with readOnlyRootFilesystem: true
+
 ## 1.7.3 (2025-04-25)
 - [#193] Fix missing dependency on bitnami common
 

--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -3,7 +3,7 @@ name: openinwoner
 description: Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
 type: application
-version: 1.7.3
+version: 1.7.4
 appVersion: 1.27.0
 icon: https://docs.openinwoner.nl/en/latest/_static/logo.png
 

--- a/charts/openinwoner/README.md
+++ b/charts/openinwoner/README.md
@@ -1,6 +1,6 @@
 # openinwoner
 
-![Version: 1.7.3](https://img.shields.io/badge/Version-1.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.27.0](https://img.shields.io/badge/AppVersion-1.27.0-informational?style=flat-square)
+![Version: 1.7.4](https://img.shields.io/badge/Version-1.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.27.0](https://img.shields.io/badge/AppVersion-1.27.0-informational?style=flat-square)
 
 Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
@@ -89,6 +89,8 @@ Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijk
 | nginx.config.basicAuth.enabled | bool | `false` | Enables nginx basic password authentication |
 | nginx.config.basicAuth.users | string | `"usernameexample:$apr1$5QwE2Ysc$ycRucgmLt0iQMMxcnu4CA/"` | You need to generate the encrypted basic auth password yourself |
 | nginx.config.clientMaxBodySize | string | `"10M"` |  |
+| nginx.extraVolumeMounts | list | `[]` |  |
+| nginx.extraVolumes | list | `[]` |  |
 | nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
 | nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` |  |
 | nginx.image.tag | string | `"stable"` |  |

--- a/charts/openinwoner/templates/deployment.yaml
+++ b/charts/openinwoner/templates/deployment.yaml
@@ -477,6 +477,9 @@ spec:
             - name: media
               mountPath: /app/media
               subPath: {{ .Values.persistence.mediaMountSubpath  | default "openinwoner/media" }}
+            {{- if .Values.nginx.extraVolumeMounts }}
+            {{- include "openinwoner.tplvalues.render" ( dict "value" .Values.nginx.extraVolumeMounts "context" $ ) | nindent 12 }}
+            {{- end }}
       volumes:
         - name: media
           persistentVolumeClaim:
@@ -493,6 +496,9 @@ spec:
           secret:
             secretName: {{ include "openinwoner.fullname" . }}-basic-auth
           {{- end }}
+        {{- if .Values.nginx.extraVolumes }}
+        {{- include "openinwoner.tplvalues.render" ( dict "value" .Values.nginx.extraVolumes "context" $ ) | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -455,6 +455,19 @@ nginx:
       # -- You need to generate the encrypted basic auth password yourself
       users: |-
         usernameexample:$apr1$5QwE2Ysc$ycRucgmLt0iQMMxcnu4CA/
+  # extraVolumes Optionally specify extra list of additional volumes
+  # e.g:
+  # extraVolumes:
+  #   - name: tmp
+  #     emptyDir: {}
+  #
+  extraVolumes: []
+  # extraVolumeMounts Optionally specify extra list of additional volumeMounts
+  # e.g:
+  # extraVolumeMounts:
+  #   - name: tmp
+  #     mountPath: /tmp
+  extraVolumeMounts: []
   service:
     type: ClusterIP
     port: 80

--- a/charts/openklant/CHANGELOG.md
+++ b/charts/openklant/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.7 (2025-06-11)
+
+- Add extra volumes and volumemounts for nginx so it can be deployed with readOnlyRootFilesystem: true
 
 ## 1.6.6 (2025-05-16)
 - Fix missing env variable USE_X_FORWARDED_HOST from web container

--- a/charts/openklant/Chart.yaml
+++ b/charts/openklant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openklant
 description: Project dat de Klanten API | https://klanten-api.vng.cloud en Contactmomenten API | https://contactmomenten-api.vng.cloud/ in een enkel component combineert.
 type: application
-version: 1.6.6
+version: 1.6.7
 appVersion: 2.5.0
 
 dependencies:

--- a/charts/openklant/README.md
+++ b/charts/openklant/README.md
@@ -1,6 +1,6 @@
 # openklant
 
-![Version: 1.6.6](https://img.shields.io/badge/Version-1.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 1.6.7](https://img.shields.io/badge/Version-1.6.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Project dat de Klanten API | https://klanten-api.vng.cloud en Contactmomenten API | https://contactmomenten-api.vng.cloud/ in een enkel component combineert.
 
@@ -64,6 +64,8 @@ Project dat de Klanten API | https://klanten-api.vng.cloud en Contactmomenten AP
 | nginx.autoscaling.enabled | bool | `false` |  |
 | nginx.config.clientMaxBodySize | string | `"10M"` |  |
 | nginx.existingConfigmap | string | `nil` |  |
+| nginx.extraVolumeMounts | list | `[]` |  |
+| nginx.extraVolumes | list | `[]` |  |
 | nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
 | nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` |  |
 | nginx.image.tag | string | `"stable"` |  |

--- a/charts/openklant/templates/deployment.yaml
+++ b/charts/openklant/templates/deployment.yaml
@@ -277,6 +277,9 @@ spec:
             - name: media
               mountPath: /app/media
               subPath: {{ .Values.persistence.mediaMountSubpath  | default "openklant/media" }}
+            {{- if .Values.nginx.extraVolumeMounts }}
+            {{- include "openklant.tplvalues.render" ( dict "value" .Values.nginx.extraVolumeMounts "context" $ ) | nindent 12 }}
+            {{- end }}
       volumes:
         - name: media
           persistentVolumeClaim:
@@ -288,6 +291,9 @@ spec:
         - name: nginx-config
           configMap:
             name: {{ if .Values.nginx.existingConfigmap }}{{ .Values.nginx.existingConfigmap  }}{{- else }}{{ include "openklant.nginxFullname" . }}{{- end }}
+        {{- if .Values.nginx.extraVolumes }}
+        {{- include "openklant.tplvalues.render" ( dict "value" .Values.nginx.extraVolumes "context" $ ) | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openklant/values.yaml
+++ b/charts/openklant/values.yaml
@@ -363,6 +363,19 @@ nginx:
     pullPolicy: IfNotPresent
     tag: stable
   existingConfigmap: null
+  # extraVolumes Optionally specify extra list of additional volumes
+  # e.g:
+  # extraVolumes:
+  #   - name: tmp
+  #     emptyDir: {}
+  #
+  extraVolumes: []
+  # extraVolumeMounts Optionally specify extra list of additional volumeMounts
+  # e.g:
+  # extraVolumeMounts:
+  #   - name: tmp
+  #     mountPath: /tmp
+  extraVolumeMounts: []
   config:
     clientMaxBodySize: 10M
   service:

--- a/charts/openzaak/CHANGELOG.md
+++ b/charts/openzaak/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.3 (2025-06-11)
+
+- Add extra volumes and volumemounts for nginx so it can be deployed with readOnlyRootFilesystem: true
+
 ## 1.8.2 (2025-04-25)
 - [#193] Fix missing dependency on bitnami common
 

--- a/charts/openzaak/Chart.yaml
+++ b/charts/openzaak/Chart.yaml
@@ -3,7 +3,7 @@ name: openzaak
 description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
-version: 1.8.2
+version: 1.8.3
 appVersion: 1.18.0
 
 dependencies:

--- a/charts/openzaak/README.md
+++ b/charts/openzaak/README.md
@@ -1,6 +1,6 @@
 # openzaak
 
-![Version: 1.8.2](https://img.shields.io/badge/Version-1.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.18.0](https://img.shields.io/badge/AppVersion-1.18.0-informational?style=flat-square)
+![Version: 1.8.3](https://img.shields.io/badge/Version-1.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.18.0](https://img.shields.io/badge/AppVersion-1.18.0-informational?style=flat-square)
 
 Productiewaardige API's voor Zaakgericht Werken
 
@@ -94,6 +94,8 @@ Productiewaardige API's voor Zaakgericht Werken
 | nameOverride | string | `""` |  |
 | nginx.autoscaling.enabled | bool | `false` |  |
 | nginx.existingConfigmap | string | `nil` | mount existing nginx vhost config |
+| nginx.extraVolumeMounts | list | `[]` |  |
+| nginx.extraVolumes | list | `[]` |  |
 | nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
 | nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` |  |
 | nginx.image.tag | string | `"stable"` |  |

--- a/charts/openzaak/templates/deployment.yaml
+++ b/charts/openzaak/templates/deployment.yaml
@@ -199,6 +199,9 @@ spec:
             - name: media
               mountPath: /app/media
               subPath: {{ .Values.persistence.mediaMountSubpath  | default "openzaak/media" }}
+            {{- if .Values.nginx.extraVolumeMounts }}
+            {{- include "openzaak.tplvalues.render" ( dict "value" .Values.nginx.extraVolumeMounts "context" $ ) | nindent 12 }}
+            {{- end }}
       volumes:
         - name: media
           persistentVolumeClaim:
@@ -210,6 +213,9 @@ spec:
         - name: nginx-config
           configMap:
             name: {{ if .Values.nginx.existingConfigmap }}{{ .Values.nginx.existingConfigmap  }}{{- else }}{{ include "openzaak.nginxFullname" . }}{{- end }}
+        {{- if .Values.nginx.extraVolumes }}
+        {{- include "openzaak.tplvalues.render" ( dict "value" .Values.nginx.extraVolumes "context" $ ) | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openzaak/values.yaml
+++ b/charts/openzaak/values.yaml
@@ -417,6 +417,19 @@ nginx:
     annotations: {}
   # -- mount existing nginx vhost config
   existingConfigmap: null
+  # extraVolumes Optionally specify extra list of additional volumes
+  # e.g:
+  # extraVolumes:
+  #   - name: tmp
+  #     emptyDir: {}
+  #
+  extraVolumes: []
+  # extraVolumeMounts Optionally specify extra list of additional volumeMounts
+  # e.g:
+  # extraVolumeMounts:
+  #   - name: tmp
+  #     mountPath: /tmp
+  extraVolumeMounts: []
   replicaCount: 1
   podLabels: {}
   securityContext:

--- a/charts/openzaaktypebeheer/CHANGELOG.md
+++ b/charts/openzaaktypebeheer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.9 (2025-06-11)
+
+- Add extra volumes and volumemounts for nginx so it can be deployed with readOnlyRootFilesystem: true

--- a/charts/openzaaktypebeheer/Chart.yaml
+++ b/charts/openzaaktypebeheer/Chart.yaml
@@ -4,7 +4,7 @@ description: An app to manage the relations between 'zaaktypen' and 'informatieo
 home: https://github.com/maykinmedia/open-zaaktypebeheer
 type: application
 # Chart version
-version: 0.1.8
+version: 0.1.9
 # Open Zaaktypebeheer version
 appVersion: "0.1.2"
 

--- a/charts/openzaaktypebeheer/README.md
+++ b/charts/openzaaktypebeheer/README.md
@@ -1,6 +1,6 @@
 # openzaaktypebeheer
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
 
 An app to manage the relations between 'zaaktypen' and 'informatieobjecttypen'.
 
@@ -41,6 +41,8 @@ An app to manage the relations between 'zaaktypen' and 'informatieobjecttypen'.
 | nameOverride | string | `""` |  |
 | nginx.autoscaling.enabled | bool | `false` |  |
 | nginx.existingConfigmap | string | `nil` |  |
+| nginx.extraVolumeMounts | list | `[]` |  |
+| nginx.extraVolumes | list | `[]` |  |
 | nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
 | nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` |  |
 | nginx.image.tag | string | `"stable"` |  |

--- a/charts/openzaaktypebeheer/templates/_helpers.tpl
+++ b/charts/openzaaktypebeheer/templates/_helpers.tpl
@@ -99,3 +99,17 @@ NGINX selector labels
 {{- define "openzaaktypebeheer.nginxSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "openzaaktypebeheer.nginxFullname" . }}
 {{- end }}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "openzaaktypebeheer.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "openzaaktypebeheer.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/charts/openzaaktypebeheer/templates/deployment.yaml
+++ b/charts/openzaaktypebeheer/templates/deployment.yaml
@@ -147,6 +147,9 @@ spec:
             - name: media
               mountPath: /app/media
               subPath: {{ .Values.persistence.mediaMountSubpath  | default "openzaaktypebeheer/media" }}
+            {{- if .Values.nginx.extraVolumeMounts }}
+            {{- include "openzaaktypebeheer.tplvalues.render" ( dict "value" .Values.nginx.extraVolumeMounts "context" $ ) | nindent 12 }}
+            {{- end }}
       volumes:
         - name: media
           persistentVolumeClaim:
@@ -158,6 +161,9 @@ spec:
         - name: nginx-config
           configMap:
             name: {{ if .Values.nginx.existingConfigmap }}{{ .Values.nginx.existingConfigmap  }}{{- else }}{{ include "openzaaktypebeheer.nginxFullname" . }}{{- end }}
+        {{- if .Values.nginx.extraVolumes }}
+        {{- include "openzaaktypebeheer.tplvalues.render" ( dict "value" .Values.nginx.extraVolumes "context" $ ) | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openzaaktypebeheer/values.yaml
+++ b/charts/openzaaktypebeheer/values.yaml
@@ -171,6 +171,19 @@ nginx:
     pullPolicy: IfNotPresent
     tag: stable
   existingConfigmap: null
+  # extraVolumes Optionally specify extra list of additional volumes
+  # e.g:
+  # extraVolumes:
+  #   - name: tmp
+  #     emptyDir: {}
+  #
+  extraVolumes: []
+  # extraVolumeMounts Optionally specify extra list of additional volumeMounts
+  # e.g:
+  # extraVolumeMounts:
+  #   - name: tmp
+  #     mountPath: /tmp
+  extraVolumeMounts: []
   service:
     type: ClusterIP
     port: 8080


### PR DESCRIPTION
This pull request will allow to set extraVolumes and extraVolumeMounts for the nginx containers used by different apps to run with readOnlyRootFilesystem: true. When this value is set to true, extra mounts needs to be set.