### PR TITLE
Upgrade Openzaak chart version reflecting app version 1.21.2

### DIFF
--- a/charts/openzaak/CHANGELOG.md
+++ b/charts/openzaak/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.0 (2025-07-09)
+
+- Upgrade the chart version with respect to Openzaak version 1.21.2 
+
 ## 1.8.4 (2025-07-09)
 
 - Adding extra env variable `zaakIdentificatieGenerator` with 2 possible values: *use-start-datum-year*, *use-creation-year* 

--- a/charts/openzaak/Chart.yaml
+++ b/charts/openzaak/Chart.yaml
@@ -3,8 +3,8 @@ name: openzaak
 description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
-version: 1.8.4
-appVersion: 1.18.0
+version: 1.9.0
+appVersion: 1.21.2
 
 dependencies:
   - name: redis

--- a/charts/openzaak/README.md
+++ b/charts/openzaak/README.md
@@ -1,6 +1,6 @@
 # openzaak
 
-![Version: 1.8.4](https://img.shields.io/badge/Version-1.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.18.0](https://img.shields.io/badge/AppVersion-1.18.0-informational?style=flat-square)
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.21.2](https://img.shields.io/badge/AppVersion-1.21.2-informational?style=flat-square)
 
 Productiewaardige API's voor Zaakgericht Werken
 


### PR DESCRIPTION
Simply reflecting the fact that the helm chart is supporting the version 1.21.1