### PR TITLE
Adding new env variable logLevel

### DIFF
--- a/charts/opennotificaties/CHANGELOG.md
+++ b/charts/opennotificaties/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.5 (2025-08-14)
+
+- Add configurable log level via LOG_LEVEL environment variable (default: INFO)
+
 ## 1.9.4 (2025-07-24)
 
 - Fixed worker deployment which was using the wrong value to determine if autoscaling is enabled (autoscaling.enabled instead of worker.autoscaling.enabled).

--- a/charts/opennotificaties/Chart.yaml
+++ b/charts/opennotificaties/Chart.yaml
@@ -3,7 +3,7 @@ name: opennotificaties
 description: API voor het routeren van notificaties
 
 type: application
-version: 1.9.4
+version: 1.9.5
 appVersion: 1.9.0
 
 dependencies:

--- a/charts/opennotificaties/README.md
+++ b/charts/opennotificaties/README.md
@@ -1,6 +1,6 @@
 # opennotificaties
 
-![Version: 1.9.3](https://img.shields.io/badge/Version-1.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.0](https://img.shields.io/badge/AppVersion-1.9.0-informational?style=flat-square)
+![Version: 1.9.5](https://img.shields.io/badge/Version-1.9.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.0](https://img.shields.io/badge/AppVersion-1.9.0-informational?style=flat-square)
 
 API voor het routeren van notificaties
 
@@ -185,6 +185,7 @@ API voor het routeren van notificaties
 | settings.flower.basicAuth | string | `""` |  |
 | settings.flower.urlPrefix | string | `""` |  |
 | settings.isHttps | bool | `true` |  |
+| settings.logLevel | string | `"INFO"` | Default value "INFO" ; Available values are CRITICAL, ERROR, WARNING, INFO and DEBUG |
 | settings.logNotifications | bool | `true` | When set to true notifications are saved to the database and accessible from the admin interface |
 | settings.maxRetries | string | `""` | The maximum number of automatic retries. After this amount of retries, Open Notificaties stops trying to deliver the message. Application default is 5. |
 | settings.numProxies | int | `1` | use 2 if enabling ingress |

--- a/charts/opennotificaties/templates/configmap.yaml
+++ b/charts/opennotificaties/templates/configmap.yaml
@@ -19,6 +19,9 @@ data:
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   {{- end }}
   CELERY_LOGLEVEL:  {{ .Values.settings.celery.logLevel | upper | toString | quote }}
+  {{- if .Values.settings.logLevel }}
+  LOG_LEVEL: {{ .Values.settings.logLevel | toString | quote }}
+  {{- end }}
   CELERY_WORKER_CONCURRENCY: {{ .Values.worker.concurrency | toString | quote }}
   CELERY_RESULT_EXPIRES: {{ .Values.settings.celery.resultExpires | toString | quote }}
   {{ if .Values.worker.maxWorkerLivenessDelta }}

--- a/charts/opennotificaties/values.yaml
+++ b/charts/opennotificaties/values.yaml
@@ -454,6 +454,8 @@ settings:
     harakiri: ''
   # -- Defines the primary domain where the application is hosted. Defaults to ""
   siteDomain: ""
+  # -- Default value "INFO" ; Available values are CRITICAL, ERROR, WARNING, INFO and DEBUG
+  logLevel: "INFO"
 
 worker:
   replicaCount: 2


### PR DESCRIPTION
Source for the env variable documentation.
https://github.com/open-zaak/open-notificaties/blob/1a393b0184a3e20741af769b906e1a95f122831d/docs/installation/configuration/env_config.rst#L51

Variable added in response to Podiumd issue IN-901, so  that more logging can be provided. 
