### PR TITLE
Openinwoner upgrade bitnami charts Redis and Common 

### DIFF
--- a/charts/openinwoner/CHANGELOG.md
+++ b/charts/openinwoner/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.8.0 (2025-08-15)
+
+- Upgraded Bitnami Elasticsearch Helm chart to version 22.1.5
+- Pinned Elasticsearch image to 9.0.3-debian-12-r1
+- Upgraded Redis Helm chart to version 22.0.1
+- Pinned Redis image to official Redis 8.0.3
+- Upgraded Bitnami Common Helm chart to version 2.31.4
+
 ## 1.7.6 (2025-07-24)
 - Fixed worker deployment which was using the wrong value to determine if autoscaling is enabled (autoscaling.enabled instead of worker.autoscaling.enabled).
 - Adding the HPA for worker deployment, (it was missing so far)

--- a/charts/openinwoner/CHANGELOG.md
+++ b/charts/openinwoner/CHANGELOG.md
@@ -1,12 +1,11 @@
 # Changelog
 
-## 1.8.0 (2025-08-15)
-
-- Upgraded Bitnami Elasticsearch Helm chart to version 22.1.5
-- Pinned Elasticsearch image to 9.0.3-debian-12-r1
-- Upgraded Redis Helm chart to version 22.0.1
-- Pinned Redis image to official Redis 8.0.3
-- Upgraded Bitnami Common Helm chart to version 2.31.4
+## 1.8.0 (2025-08-22)
+##### Upgraded 
+- Redis Bitnami Helm subchart to version `22.0.1`
+- Common Bitnami Helm subchart to version `2.31.4`
+##### Changed
+- Redis: Migrated from Bitnami to official Redis container image (`8.0`) [pinned] 
 
 ## 1.7.6 (2025-07-24)
 - Fixed worker deployment which was using the wrong value to determine if autoscaling is enabled (autoscaling.enabled instead of worker.autoscaling.enabled).

--- a/charts/openinwoner/Chart.lock
+++ b/charts/openinwoner/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.3.14
+  version: 22.0.1
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 19.5.11
+  version: 22.1.5
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.27.0
-digest: sha256:8a3211c126312a5bf6734eeff7d9c95eefc099ae06338d6daee1a5405808e84f
-generated: "2025-07-25T17:11:14.896788413+02:00"
+  version: 2.31.4
+digest: sha256:bc1a4f47d7cdaca9a55dc5d2859a7bb837393de9e9d4a46fa626c42d2359742e
+generated: "2025-08-13T12:47:30.324993561+02:00"

--- a/charts/openinwoner/Chart.lock
+++ b/charts/openinwoner/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 22.0.1
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 22.1.5
+  version: 19.5.11
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.31.4
-digest: sha256:bc1a4f47d7cdaca9a55dc5d2859a7bb837393de9e9d4a46fa626c42d2359742e
-generated: "2025-08-13T12:47:30.324993561+02:00"
+digest: sha256:51ddfb1f155d02750437412cb3d15c96db81ed6fa742943ddc4590f9e3e980cb
+generated: "2025-08-22T14:53:11.075049278+02:00"

--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -9,17 +9,17 @@ icon: https://docs.openinwoner.nl/en/latest/_static/logo.png
 
 dependencies:
   - name: redis
-    version: 17.3.14
+    version: 22.0.1  #17.3.14 
     repository: https://charts.bitnami.com/bitnami
     tags:
       - redis
   - name: elasticsearch
-    version: 19.5.11
+    version: 22.1.5  #19.5.11
     repository: https://charts.bitnami.com/bitnami
     tags:
       - elasticsearch
   - name: common
-    version: 2.27.0
+    version: 2.31.4  #2.27.0
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common

--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -9,17 +9,17 @@ icon: https://docs.openinwoner.nl/en/latest/_static/logo.png
 
 dependencies:
   - name: redis
-    version: 22.0.1  #17.3.14 
+    version: 22.0.1
     repository: https://charts.bitnami.com/bitnami
     tags:
       - redis
   - name: elasticsearch
-    version: 22.1.5  #19.5.11
+    version: 22.1.5
     repository: https://charts.bitnami.com/bitnami
     tags:
       - elasticsearch
   - name: common
-    version: 2.31.4  #2.27.0
+    version: 2.31.4
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common

--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     tags:
       - redis
   - name: elasticsearch
-    version: 22.1.5
+    version: 19.5.11
     repository: https://charts.bitnami.com/bitnami
     tags:
       - elasticsearch

--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -3,7 +3,7 @@ name: openinwoner
 description: Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
 type: application
-version: 1.7.6
+version: 1.8.0
 appVersion: 1.32.0
 icon: https://docs.openinwoner.nl/en/latest/_static/logo.png
 

--- a/charts/openinwoner/README.md
+++ b/charts/openinwoner/README.md
@@ -9,7 +9,7 @@ Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijk
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | common | 2.31.4 |
-| https://charts.bitnami.com/bitnami | elasticsearch | 22.1.5 |
+| https://charts.bitnami.com/bitnami | elasticsearch | 19.5.11 |
 | https://charts.bitnami.com/bitnami | redis | 22.0.1 |
 
 ## Values
@@ -49,7 +49,6 @@ Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijk
 | elasticsearch.data.resources.limits | object | `{}` |  |
 | elasticsearch.data.resources.requests.cpu | string | `"100m"` |  |
 | elasticsearch.data.resources.requests.memory | string | `"512Mi"` |  |
-| elasticsearch.image.tag | string | `"9.0.3-debian-12-r1"` |  |
 | elasticsearch.ingest.enabled | bool | `false` |  |
 | elasticsearch.master.masterOnly | bool | `true` |  |
 | elasticsearch.master.persistence.enabled | bool | `true` |  |
@@ -137,9 +136,7 @@ Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijk
 | readinessProbe.timeoutSeconds | int | `5` |  |
 | redis.architecture | string | `"standalone"` |  |
 | redis.auth.enabled | bool | `false` |  |
-| redis.image.registry | string | `"docker.io"` |  |
-| redis.image.repository | string | `"redis"` |  |
-| redis.image.tag | string | `"8.0.3"` |  |
+| redis.image | object | `{"registry":"docker.io","repository":"redis","tag":"8.0"}` | Redis image configuration - Migration from Bitnami to official Redis image           |
 | redis.master.persistence.enabled | bool | `true` |  |
 | redis.master.persistence.size | string | `"8Gi"` |  |
 | redis.master.persistence.storageClass | string | `""` |  |

--- a/charts/openinwoner/README.md
+++ b/charts/openinwoner/README.md
@@ -1,6 +1,6 @@
 # openinwoner
 
-![Version: 1.7.5](https://img.shields.io/badge/Version-1.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.32.0](https://img.shields.io/badge/AppVersion-1.32.0-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.32.0](https://img.shields.io/badge/AppVersion-1.32.0-informational?style=flat-square)
 
 Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
@@ -8,9 +8,9 @@ Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijk
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 2.27.0 |
-| https://charts.bitnami.com/bitnami | elasticsearch | 19.5.11 |
-| https://charts.bitnami.com/bitnami | redis | 17.3.14 |
+| https://charts.bitnami.com/bitnami | common | 2.31.4 |
+| https://charts.bitnami.com/bitnami | elasticsearch | 22.1.5 |
+| https://charts.bitnami.com/bitnami | redis | 22.0.1 |
 
 ## Values
 
@@ -49,6 +49,7 @@ Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijk
 | elasticsearch.data.resources.limits | object | `{}` |  |
 | elasticsearch.data.resources.requests.cpu | string | `"100m"` |  |
 | elasticsearch.data.resources.requests.memory | string | `"512Mi"` |  |
+| elasticsearch.image.tag | string | `"9.0.3-debian-12-r1"` |  |
 | elasticsearch.ingest.enabled | bool | `false` |  |
 | elasticsearch.master.masterOnly | bool | `true` |  |
 | elasticsearch.master.persistence.enabled | bool | `true` |  |
@@ -136,6 +137,9 @@ Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijk
 | readinessProbe.timeoutSeconds | int | `5` |  |
 | redis.architecture | string | `"standalone"` |  |
 | redis.auth.enabled | bool | `false` |  |
+| redis.image.registry | string | `"docker.io"` |  |
+| redis.image.repository | string | `"redis"` |  |
+| redis.image.tag | string | `"8.0.3"` |  |
 | redis.master.persistence.enabled | bool | `true` |  |
 | redis.master.persistence.size | string | `"8Gi"` |  |
 | redis.master.persistence.storageClass | string | `""` |  |

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -512,10 +512,6 @@ nginx:
 ##################
 
 redis:
-  image:
-    registry: docker.io
-    repository: redis # official redis image
-    tag: "8.0.3"
   architecture: standalone
   auth:
     enabled: false
@@ -528,14 +524,17 @@ redis:
       requests:
         cpu: 250m
         memory: 256Mi
+  # -- Redis image configuration - Migration from Bitnami to official Redis image          
+  image:
+    registry: docker.io  # Docker registry for Redis image
+    repository: redis  # Official Redis image (migrated from Bitnami)
+    tag: "8.0"  # Official Redis image pinned version
 
 ##########################
 # elasticsearch subchart #
 ##########################
 
 elasticsearch:
-  image:
-    tag: 9.0.3-debian-12-r1
   master:
     masterOnly: true
     replicaCount: 1

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -512,6 +512,10 @@ nginx:
 ##################
 
 redis:
+  image:
+    registry: docker.io
+    repository: redis # official redis image
+    tag: "8.0.3"
   architecture: standalone
   auth:
     enabled: false
@@ -530,6 +534,8 @@ redis:
 ##########################
 
 elasticsearch:
+  image:
+    tag: 9.0.3-debian-12-r1
   master:
     masterOnly: true
     replicaCount: 1


### PR DESCRIPTION
Here we upgrade to the latest Bitnami charts before the change of the policy.
For the Redis chart the official Redis image is pinned, which appears to work correctly.
The Bitnami image is pinned for the Elasticsearch sub-chart. 

linked to the another PR which can be closed  -> https://github.com/maykinmedia/charts/pull/248

https://github.com/maykinmedia/charts/issues/247