### PR TITLE
Pinning the elasticsearch version to Bitnami's 9.0.3

### DIFF
--- a/charts/openinwoner/CHANGELOG.md
+++ b/charts/openinwoner/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.10.0 (2025-08-26)
+- Pinned Elasticsearch image to 9.0.3-debian-12-r1
+
 ## 1.9.0 (2025-08-25)
 
 ### Upgraded

--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -3,7 +3,7 @@ name: openinwoner
 description: Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
 type: application
-version: 1.9.0
+version: 1.10.0
 appVersion: 1.32.0
 icon: https://docs.openinwoner.nl/en/latest/_static/logo.png
 

--- a/charts/openinwoner/README.md
+++ b/charts/openinwoner/README.md
@@ -1,6 +1,6 @@
 # openinwoner
 
-![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.32.0](https://img.shields.io/badge/AppVersion-1.32.0-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.32.0](https://img.shields.io/badge/AppVersion-1.32.0-informational?style=flat-square)
 
 Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
@@ -50,6 +50,7 @@ Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijk
 | elasticsearch.data.resources.requests.cpu | string | `"100m"` |  |
 | elasticsearch.data.resources.requests.memory | string | `"512Mi"` |  |
 | elasticsearch.image.repository | string | `"bitnamilegacy/elasticsearch"` |  |
+| elasticsearch.image.tag | string | `"9.0.3-debian-12-r1"` |  |
 | elasticsearch.ingest.enabled | bool | `false` |  |
 | elasticsearch.master.masterOnly | bool | `true` |  |
 | elasticsearch.master.persistence.enabled | bool | `true` |  |

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -564,3 +564,4 @@ elasticsearch:
     enabled: false
   image:
     repository: bitnamilegacy/elasticsearch  # Temporary: legacy Bitnami repo.
+    tag: 9.0.3-debian-12-r1  # Legacy Elasticsearch image pinned version


### PR DESCRIPTION
As discussed in https://github.com/maykinmedia/charts/pull/270 
creating a separate PR for ES version 