### PR TITLE
Fix changelog url

### DIFF
--- a/charts/openforms/README.md.gotmpl
+++ b/charts/openforms/README.md.gotmpl
@@ -11,7 +11,7 @@ This chart can be used to deploy Open Forms on a Kubernetes cluster using the He
 * [Source code](https://github.com/open-formulieren/open-forms/)
 * [Documentation](https://open-forms.readthedocs.io/)
 * [Docker image](https://hub.docker.com/r/openformulieren/open-forms)
-* [Changelog](https://open-forms.readthedocs.io/en/3.3.0/changelog.html)
+* [Changelog](https://open-forms.readthedocs.io/en/stable/changelog.html)
 
 ## Quickstart
 


### PR DESCRIPTION
The generic README should point to the stable docs instead of pinning it on a particular release version.

The changelog entries should indeed point to particular versions.