### PR TITLE
Fix bug preventing WAITING_PERIOD env var to be set to zero in OAB

### DIFF
--- a/charts/openarchiefbeheer/CHANGELOG.md
+++ b/charts/openarchiefbeheer/CHANGELOG.md
@@ -39,6 +39,7 @@ For the upgrade of the yaml used to configure the OIDC login, look at the `value
 
 - Added a README template.
 - Removed chart dependency on `maykin-utils-lib`
+- Fixed bug preventing us from setting `WAITING_PERIOD` to `0`. Now the chart sets it to `7` by default in the same way as the app.
 
 
 

--- a/charts/openarchiefbeheer/Chart.yaml
+++ b/charts/openarchiefbeheer/Chart.yaml
@@ -3,7 +3,7 @@ name: openarchiefbeheer
 description: Opstellen, beheren en uitvoeren van vernietigingslijsten, voor gebruik met Zaakgericht werken
 
 type: application
-version: 2.0.0-rc.0
+version: 2.0.0-rc.1
 appVersion: 2.0.0
 
 dependencies:

--- a/charts/openarchiefbeheer/README.md
+++ b/charts/openarchiefbeheer/README.md
@@ -2,7 +2,7 @@
 
 Opstellen, beheren en uitvoeren van vernietigingslijsten, voor gebruik met Zaakgericht werken
 
-![Version: 2.0.0-rc.0](https://img.shields.io/badge/Version-2.0.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.0-rc.1](https://img.shields.io/badge/Version-2.0.0--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 ## Introduction
 
@@ -233,7 +233,7 @@ how to configure, see the Open Archiefbeheer [example](https://github.com/maykin
 | settings.uwsgi.maxRequests | string | `""` |  |
 | settings.uwsgi.processes | string | `""` |  |
 | settings.uwsgi.threads | string | `""` |  |
-| settings.waitingPeriod | string | `""` | Number of days to wait before destroying a list. Defaults to 7 in the application. |
+| settings.waitingPeriod | string | `"7"` | Number of days to wait before destroying a list. Defaults to 7 in the application. |
 | tags.redis | bool | `true` |  |
 | tolerations | list | `[]` |  |
 | worker.autoscaling.enabled | bool | `false` |  |

--- a/charts/openarchiefbeheer/templates/configmap.yaml
+++ b/charts/openarchiefbeheer/templates/configmap.yaml
@@ -105,9 +105,7 @@ data:
   {{- if .Values.settings.retry.statusForcelist }}
   RETRY_STATUS_FORCELIST: {{ .Values.settings.retry.statusForcelist | toString | quote }}
   {{- end }}
-  {{- if .Values.settings.waitingPeriod }}
   WAITING_PERIOD: {{ .Values.settings.waitingPeriod | toString | quote }}
-  {{- end }}
   OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS: {{ .Values.settings.oidcRenewIdTokenExpirySeconds | toString | quote }}
   SESSION_COOKIE_AGE: {{ .Values.settings.sessionCookieAge | toString | quote }}
   LOG_STDOUT: {{ if .Values.settings.logging.toStdout }}"True"{{ else }}"False"{{ end }}

--- a/charts/openarchiefbeheer/values.yaml
+++ b/charts/openarchiefbeheer/values.yaml
@@ -254,7 +254,7 @@ settings:
   environment: ""
   requestsReadTimeout: "30"
   # -- Number of days to wait before destroying a list. Defaults to 7 in the application.
-  waitingPeriod: ""
+  waitingPeriod: "7"
   # -- Number of days for which destruction lists will be visible after successfull destruction.
   postDestructionVisibilityPeriod: "7"
   # -- If true, the inline presentation of the related objects will be disabled. This reduces load on external registers and improves performance.


### PR DESCRIPTION
Found this problem during chain tests on our Flux env