### PR TITLE
:bookmark: Release open zaak chart 1.14.0

### DIFF
--- a/charts/openzaak/CHANGELOG.md
+++ b/charts/openzaak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.14.0 (XXXX-XX-XX)
+## 1.14.0 (2026-02-13)
 
 - Bumped the application version to 1.27.0.
 - Added support for the environment variables to configure Azure Blob Storage and S3 storage for the Documenten API.
@@ -18,17 +18,17 @@
 
 ⚠️ This release contains breaking changes.
 
-With the upgrade from openzaak 1.25.0 to 1.26.0 is mozilla-django-oidc-db bumped to 1.1.0. This requires a new data format. 
+With the upgrade from openzaak 1.25.0 to 1.26.0 is mozilla-django-oidc-db bumped to 1.1.0. This requires a new data format.
 
 The new configuration must be used, as it splits the previous solo model configuration into OIDCProvider and OIDCClient configurations, making it easier to re-use identity provider settings across multiple client IDs.
 
-Refer to the example in the values file or consult the openzaak configuration documentation. 
+Refer to the example in the values file or consult the openzaak configuration documentation.
 
 **Changes**
 - update openzaak container version to 1.26.0
 - update examples in values.yaml to reflect the expected new OIDC config
 - Include new values for openTelemetrySDK support. Check openzaak documentation for more info.
- 
+
 ---
 
 
@@ -40,7 +40,7 @@ Refer to the example in the values file or consult the openzaak configuration do
 
 The application version was updated to `1.25.0`. This version of the application uses version `0.9.0` of the `django-setup-configuration` library.
 
-This version of `django-setup-configuration` removes the need to use `envsubst` to inject secrets into the yaml file used to 
+This version of `django-setup-configuration` removes the need to use `envsubst` to inject secrets into the yaml file used to
 configure the application. It supports extracting secrets directly from environment variables.
 
 ---
@@ -58,7 +58,7 @@ oidc_rp_client_secret:
   value_from:
     env: KEYCLOAK_CLIENT_SECRET
 ```
-Note: It is still possible to specify values directly. 
+Note: It is still possible to specify values directly.
 **Changes**
 - Updated application to version 1.25.0.
 - Updated job-config to no longer perform the `envsubst` command.
@@ -72,14 +72,14 @@ Note: It is still possible to specify values directly.
   - Add startup probe with 5+ minute timeout for application initialization
   - Configuration: 15s initial delay + 30 failures × 10s period = 5 minutes 15 seconds total
   - Prevents premature pod restarts during complex startup scenarios (database migrations, static file collection)
-- Updated health check probes to use `/admin/` endpoint instead of `/` for better application readiness detection  
+- Updated health check probes to use `/admin/` endpoint instead of `/` for better application readiness detection
 
 ## 1.11.0 (2025-08-08)
 
 - [open-zaak/open-zaak#2132] Expose `result_expires` Celery setting via environment variable `CELERY_RESULT_EXPIRES`.
 - Add TIME_LEEWAY environment variable for JWT validation time tolerance (replaces deprecated JWT_LEEWAY) (default: nil)
 - Add DB_DISABLE_SERVER_SIDE_CURSORS environment variable to prevent cursor-related errors (default: false)
-- Add 8 environment variables (`DB_POOL_MIN_SIZE`, `DB_POOL_MAX_SIZE`, `DB_POOL_TIMEOUT`, `DB_POOL_MAX_WAITING`, `DB_POOL_MAX_LIFETIME`, `DB_POOL_MAX_IDLE`, `DB_POOL_RECONNECT_TIMEOUT`, `DB_POOL_NUM_WORKERS`) for database connection pooling settings. 
+- Add 8 environment variables (`DB_POOL_MIN_SIZE`, `DB_POOL_MAX_SIZE`, `DB_POOL_TIMEOUT`, `DB_POOL_MAX_WAITING`, `DB_POOL_MAX_LIFETIME`, `DB_POOL_MAX_IDLE`, `DB_POOL_RECONNECT_TIMEOUT`, `DB_POOL_NUM_WORKERS`) for database connection pooling settings.
 - Added `DB_CONN_MAX_AGE` environment variable.
 
 ## 1.10.1 (2025-08-28)
@@ -88,19 +88,19 @@ Note: It is still possible to specify values directly.
 - Removing individual endpoints for nginx config locations, namely `/documenten/api/v1/enkelvoudiginformatieobjecten` and `/documenten/api/v1/bestandsdelen`.
 
 ## 1.10.0 (2025-08-23)
-##### Upgraded 
+##### Upgraded
 - Redis Bitnami Helm subchart to version `22.0.1`
 - Common Bitnami Helm subchart to version `2.31.4`
 ##### Changed
-- Redis: Migrated from Bitnami to official Redis container image (`8.0`) [pinned] 
+- Redis: Migrated from Bitnami to official Redis container image (`8.0`) [pinned]
 
 ## 1.9.0 (2025-07-09)
 
-- Upgrade the chart version with respect to Openzaak version 1.21.2 
+- Upgrade the chart version with respect to Openzaak version 1.21.2
 
 ## 1.8.4 (2025-07-09)
 
-- Adding extra env variable `zaakIdentificatieGenerator` with 2 possible values: *use-start-datum-year*, *use-creation-year* 
+- Adding extra env variable `zaakIdentificatieGenerator` with 2 possible values: *use-start-datum-year*, *use-creation-year*
 - Adding env variable `siteDomain` defines primary domain of Openzaak
 
 ## 1.8.3 (2025-06-11)
@@ -116,7 +116,7 @@ Note: It is still possible to specify values directly.
 
 ## 1.8.0 (2025-02-17)
 
-Stable release with support of [django-setup-configuration](https://github.com/maykinmedia/django-setup-configuration). 
+Stable release with support of [django-setup-configuration](https://github.com/maykinmedia/django-setup-configuration).
 
 - Fixed the configuration-secrets.yaml template to render only if no existing secret is present in the cluster (needed for example if using sealed secrets).
 - Removed support for the following environment variables: `SITES_CONFIG_ENABLE`, `OPENZAAK_DOMAIN`, `OPENZAAK_ORGANIZATION`, `NOTIF_OPENZAAK_CONFIG_ENABLE`, `NOTIF_OPENZAAK_CLIENT_ID`, `OPENZAAK_NOTIF_CONFIG_ENABLE`, `NOTIF_API_ROOT`, `OPENZAAK_NOTIF_CLIENT_ID`, `OPENZAAK_SELECTIELIJST_CONFIG_ENAB`, `SELECTIELIJST_API_ROOT`, `SELECTIELIJST_API_OAS`, `SELECTIELIJST_ALLOWED_YEARS`, `SELECTIELIJST_DEFAULT_YEAR`. The settings that used to be configured with these variables can now be configured via django setup configuration.

--- a/charts/openzaak/Chart.yaml
+++ b/charts/openzaak/Chart.yaml
@@ -3,7 +3,7 @@ name: openzaak
 description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
-version: 1.14.0-rc.0
+version: 1.14.0
 appVersion: 1.27.0
 
 dependencies:

--- a/charts/openzaak/README.md
+++ b/charts/openzaak/README.md
@@ -2,7 +2,7 @@
 
 Productiewaardige API's voor Zaakgericht Werken
 
-![Version: 1.14.0-rc.0](https://img.shields.io/badge/Version-1.14.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.27.0](https://img.shields.io/badge/AppVersion-1.27.0-informational?style=flat-square)
+![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.27.0](https://img.shields.io/badge/AppVersion-1.27.0-informational?style=flat-square)
 
 ## Introduction
 


### PR DESCRIPTION
1.14.0-rc.0 was released first and deployed on the k8s testenv to verify that the Azure blob storage documenten API backend works