### PR TITLE
Reorder ALLOWED_HOSTS in configmap.yaml

### DIFF
--- a/charts/openinwoner/templates/configmap.yaml
+++ b/charts/openinwoner/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   DJANGO_SETTINGS_MODULE: {{ .Values.settings.djangoSettingsModule | toString | quote }}
   ENVIRONMENT: {{ .Values.settings.environment | default (include "openinwoner.fullname" .) }}
-  ALLOWED_HOSTS: "{{ include "openinwoner.fullname" . }},{{ include "openinwoner.fullname" . }}.{{ .Release.Namespace }},{{ .Values.settings.allowedHosts | replace " " "" | toString }}"
+  ALLOWED_HOSTS: "{{ .Values.settings.allowedHosts | replace " " "" | toString }},{{ include "openinwoner.fullname" . }},{{ include "openinwoner.fullname" . }}.{{ .Release.Namespace }}"
   {{- if (index .Values "eck-elasticsearch" "enabled") }}
   ES_HOST: {{ printf "http://%s-es-http:9200" (index .Values "eck-elasticsearch" "fullnameOverride") | quote }}
   {{ else }}


### PR DESCRIPTION
openinwoner makes use of the first ALLOWED_HOSTS entry as the BASE_URL, which is used in (at least) the verification-email link for determining the full URL of the environment. Unfortunately the first ALLOWED_HOSTS entry isn't easily configured via the values, so I've swapped this around in the helm chart