### PR TITLE
Open Inwoner 2.3.0 chart updates

### DIFF
--- a/charts/openinwoner/CHANGELOG.md
+++ b/charts/openinwoner/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.2.0 (2026-05-29)
+
+- Bumped the app version to `2.3.0`.
+- Added `settings.cms4MigrationInitContainer` (default: `true`) - an init container that runs
+  `python /app/src/manage.py cms4_migration`. Enabled by default to ensure the migration runs
+  on the initial rollout to 2.3.0. Once it has completed successfully it can be set to `false`
+  to prevent it from re-running on every pod restart.
+- Added `lowLatencyWorker` - a dedicated Celery worker for the `low-latency` queue
+  (concurrency 8), keeping the default worker unchanged.
+- Exposed `settings.zgwApisCacheDuration` to configure the ZGW cache timeout.
+- Configured the `low-latency` queue for cache seeding tasks via `settings.cacheSeederQueue`.
+
 ## 2.1.1 (2026-02-06)
 
 - Fixed typo in the readme.

--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -3,8 +3,8 @@ name: openinwoner
 description: Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
 type: application
-version: 2.1.5
-appVersion: 2.2.0
+version: 2.2.0
+appVersion: 2.3.0
 
 icon: https://docs.openinwoner.nl/en/latest/_static/logo.png
 

--- a/charts/openinwoner/README.md
+++ b/charts/openinwoner/README.md
@@ -397,6 +397,7 @@ The value of the `DSN` is considered sensitive, so it should be handled as a sec
 | settings.brpVersion | string | `""` |  |
 | settings.cache.axes | string | `""` | Sets 'CACHE_AXES' var, only required when tags.redis is false |
 | settings.cache.default | string | `""` | Sets 'CACHE_DEFAULT' var, only required when tags.redis is false |
+| settings.cacheSeedingQueue | string | `""` | The Celery queue used for cache seeding tasks. Defaults to the low-latency worker queue. |
 | settings.cacheZgwZakenTimeout | string | `""` | Timeout in seconds for cached ZGW zaken requests. Leave empty to use the application default. |
 | settings.celery.brokerUrl | string | `""` |  |
 | settings.celery.logLevel | string | `"debug"` |  |

--- a/charts/openinwoner/README.md
+++ b/charts/openinwoner/README.md
@@ -301,6 +301,26 @@ The value of the `DSN` is considered sensitive, so it should be handled as a sec
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.successThreshold | int | `1` |  |
 | livenessProbe.timeoutSeconds | int | `5` |  |
+| lowLatencyWorker.autoscaling.enabled | bool | `false` |  |
+| lowLatencyWorker.autoscaling.maxReplicas | int | `100` |  |
+| lowLatencyWorker.autoscaling.minReplicas | int | `1` |  |
+| lowLatencyWorker.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| lowLatencyWorker.autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
+| lowLatencyWorker.concurrency | int | `8` |  |
+| lowLatencyWorker.livenessProbe.enabled | bool | `false` |  |
+| lowLatencyWorker.livenessProbe.exec.command[0] | string | `"/bin/sh"` |  |
+| lowLatencyWorker.livenessProbe.exec.command[1] | string | `"-c"` |  |
+| lowLatencyWorker.livenessProbe.exec.command[2] | string | `"celery --workdir src --app open_inwoner.celery inspect --destination celery@${HOSTNAME} active"` |  |
+| lowLatencyWorker.livenessProbe.failureThreshold | int | `3` |  |
+| lowLatencyWorker.livenessProbe.initialDelaySeconds | int | `60` |  |
+| lowLatencyWorker.livenessProbe.periodSeconds | int | `50` |  |
+| lowLatencyWorker.livenessProbe.successThreshold | int | `1` |  |
+| lowLatencyWorker.livenessProbe.timeoutSeconds | int | `10` |  |
+| lowLatencyWorker.maxWorkerLivenessDelta | string | `""` |  |
+| lowLatencyWorker.podLabels | object | `{}` |  |
+| lowLatencyWorker.queue | string | `"low-latency"` |  |
+| lowLatencyWorker.replicaCount | int | `1` |  |
+| lowLatencyWorker.resources | object | `{}` |  |
 | nameOverride | string | `""` |  |
 | nginx.autoscaling.enabled | bool | `false` |  |
 | nginx.config.basicAuth | object | `{"enabled":false,"users":"usernameexample:$apr1$5QwE2Ysc$ycRucgmLt0iQMMxcnu4CA/"}` | Configure nginx basic authentication, only use if you are unable to set it on your ingress controller |

--- a/charts/openinwoner/README.md
+++ b/charts/openinwoner/README.md
@@ -354,7 +354,7 @@ The value of the `DSN` is considered sensitive, so it should be handled as a sec
 | readinessProbe.timeoutSeconds | int | `5` |  |
 | redis.architecture | string | `"standalone"` |  |
 | redis.auth.enabled | bool | `false` |  |
-| redis.image | object | `{"registry":"docker.io","repository":"redis","tag":"8.0"}` | Redis image configuration - Migration from Bitnami to official Redis image           |
+| redis.image | object | `{"registry":"docker.io","repository":"redis","tag":"8.0"}` | Redis image configuration - Migration from Bitnami to official Redis image |
 | redis.master.persistence.enabled | bool | `true` |  |
 | redis.master.persistence.size | string | `"8Gi"` |  |
 | redis.master.persistence.storageClass | string | `""` |  |
@@ -380,6 +380,7 @@ The value of the `DSN` is considered sensitive, so it should be handled as a sec
 | settings.celery.brokerUrl | string | `""` |  |
 | settings.celery.logLevel | string | `"debug"` |  |
 | settings.celery.resultBackend | string | `""` |  |
+| settings.cms4MigrationInitContainer | bool | `true` | Runs an init container that executes `python /app/src/manage.py cms4_migration`. Enabled by default to ensure the migration runs on the initial rollout to 2.3.0. This migration only needs to run once: once it has completed successfully, set this to false to avoid re-running it on every pod restart. |
 | settings.database.host | string | `""` |  |
 | settings.database.name | string | `""` |  |
 | settings.database.password | string | `""` |  |
@@ -417,7 +418,7 @@ The value of the `DSN` is considered sensitive, so it should be handled as a sec
 | settings.otel.resourceAttributes | list | `[]` | Resources Attributes can be used to specify additional information about the instance. |
 | settings.searchIndexInitContainer | bool | `false` |  |
 | settings.secretKey | string | `""` | Generate secret key at https://djecrety.ir/ |
-| settings.secretKeyFallback | string | `""` | This optional setting can be used to rotate a secret key, by moving a new value into secretKey, and moving the previous secretKey into secretKeyFallback.  |
+| settings.secretKeyFallback | string | `""` | This optional setting can be used to rotate a secret key, by moving a new value into secretKey, and moving the previous secretKey into secretKeyFallback. |
 | settings.sentry.dsn | string | `""` |  |
 | settings.smsgateway.apikey | string | `""` |  |
 | settings.smsgateway.backend | string | `""` | For example "open_inwoner.accounts.gateways.MessageBird" |
@@ -432,7 +433,7 @@ The value of the `DSN` is considered sensitive, so it should be handled as a sec
 | settings.uwsgi.threads | string | `""` |  |
 | settings.zgwMaxRequests | string | `""` | The maximum number of requests allowed for fetching zaken on the Mijn Zaken page. The total number of zaken fetched will be this number multiplied by the page size of the ZGW backend's zaken endpoint. |
 | startupProbe.failureThreshold | int | `30` |  |
-| startupProbe.initialDelaySeconds | int | `15` | Total time: 15s initial delay + (30 failures × 10s period) = 315s (5 minutes 15 seconds)     |
+| startupProbe.initialDelaySeconds | int | `15` | Total time: 15s initial delay + (30 failures × 10s period) = 315s (5 minutes 15 seconds) |
 | startupProbe.periodSeconds | int | `10` |  |
 | startupProbe.successThreshold | int | `1` |  |
 | startupProbe.timeoutSeconds | int | `5` |  |

--- a/charts/openinwoner/README.md
+++ b/charts/openinwoner/README.md
@@ -2,7 +2,7 @@
 
 Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
-![Version: 2.1.5](https://img.shields.io/badge/Version-2.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 ## Introduction
 

--- a/charts/openinwoner/README.md
+++ b/charts/openinwoner/README.md
@@ -397,6 +397,7 @@ The value of the `DSN` is considered sensitive, so it should be handled as a sec
 | settings.brpVersion | string | `""` |  |
 | settings.cache.axes | string | `""` | Sets 'CACHE_AXES' var, only required when tags.redis is false |
 | settings.cache.default | string | `""` | Sets 'CACHE_DEFAULT' var, only required when tags.redis is false |
+| settings.cacheZgwZakenTimeout | string | `""` | Timeout in seconds for cached ZGW zaken requests. Leave empty to use the application default. |
 | settings.celery.brokerUrl | string | `""` |  |
 | settings.celery.logLevel | string | `"debug"` |  |
 | settings.celery.resultBackend | string | `""` |  |

--- a/charts/openinwoner/templates/_helpers.tpl
+++ b/charts/openinwoner/templates/_helpers.tpl
@@ -161,6 +161,37 @@ app.kubernetes.io/name: {{ include "openinwoner.workerName" . }}
 {{- end }}
 
 {{/*
+Create a name for the low latency worker
+We truncate at 42 chars in order to provide space for the "-low-latency-worker" suffix
+*/}}
+{{- define "openinwoner.lowLatencyWorkerName" -}}
+{{ include "openinwoner.name" . | trunc 42 | trimSuffix "-" }}-low-latency-worker
+{{- end }}
+
+{{/*
+Create a default fully qualified name for the low latency worker.
+We truncate at 42 chars in order to provide space for the "-low-latency-worker" suffix
+*/}}
+{{- define "openinwoner.lowLatencyWorkerFullname" -}}
+{{ include "openinwoner.fullname" . | trunc 42 | trimSuffix "-" }}-low-latency-worker
+{{- end }}
+
+{{/*
+Low latency worker labels
+*/}}
+{{- define "openinwoner.lowLatencyWorkerLabels" -}}
+{{ include "openinwoner.commonLabels" . }}
+{{ include "openinwoner.lowLatencyWorkerSelectorLabels" . }}
+{{- end }}
+
+{{/*
+Low latency worker selector labels
+*/}}
+{{- define "openinwoner.lowLatencyWorkerSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "openinwoner.lowLatencyWorkerName" . }}
+{{- end }}
+
+{{/*
 Create a name for the celery beat
 We truncate at 56 chars in order to provide space for the "-beat" suffix
 */}}

--- a/charts/openinwoner/templates/configmap.yaml
+++ b/charts/openinwoner/templates/configmap.yaml
@@ -94,6 +94,9 @@ data:
   {{- if .Values.settings.zgwMaxRequests }}
   ZGW_MAX_REQUESTS: {{ .Values.settings.zgwMaxRequests | toString | quote }}
   {{- end }}
+  {{- if .Values.settings.cacheZgwZakenTimeout }}
+  CACHE_ZGW_ZAKEN_TIMEOUT: {{ .Values.settings.cacheZgwZakenTimeout | toString | quote }}
+  {{- end }}
   OTEL_SDK_DISABLED: {{ if .Values.settings.otel.disabled }}"True"{{ else }}"False"{{ end }}
   {{- if not .Values.settings.otel.disabled }}
   OTEL_RESOURCE_ATTRIBUTES: "{{ range $index, $item := .Values.settings.otel.resourceAttributes }}{{ if $index }},{{ end }}{{ .key }}={{ .value }}{{ end }}"

--- a/charts/openinwoner/templates/configmap.yaml
+++ b/charts/openinwoner/templates/configmap.yaml
@@ -97,6 +97,7 @@ data:
   {{- if .Values.settings.cacheZgwZakenTimeout }}
   CACHE_ZGW_ZAKEN_TIMEOUT: {{ .Values.settings.cacheZgwZakenTimeout | toString | quote }}
   {{- end }}
+  CACHE_SEEDING_QUEUE: {{ .Values.settings.cacheSeedingQueue | default .Values.lowLatencyWorker.queue | toString | quote }}
   OTEL_SDK_DISABLED: {{ if .Values.settings.otel.disabled }}"True"{{ else }}"False"{{ end }}
   {{- if not .Values.settings.otel.disabled }}
   OTEL_RESOURCE_ATTRIBUTES: "{{ range $index, $item := .Values.settings.otel.resourceAttributes }}{{ if $index }},{{ end }}{{ .key }}={{ .value }}{{ end }}"

--- a/charts/openinwoner/templates/deployment.yaml
+++ b/charts/openinwoner/templates/deployment.yaml
@@ -32,11 +32,12 @@ spec:
       serviceAccountName: {{ include "openinwoner.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.settings.searchIndexInitContainer }}
+      {{- if or .Values.settings.searchIndexInitContainer .Values.settings.cms4MigrationInitContainer }}
       initContainers:
-        - name: {{ .Chart.Name }}-search-index
+        {{- if .Values.settings.cms4MigrationInitContainer }}
+        - name: {{ .Chart.Name }}-cms4-migration
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 16 }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
@@ -44,23 +45,20 @@ spec:
                 name: {{ .Values.existingSecret | default (include "openinwoner.fullname" .) }}
             - configMapRef:
                 name: {{ include "openinwoner.fullname" . }}
-            - secretRef:
-                name: {{ include "openinwoner.fullname" . }}-config-secrets
           env:
             {{- if .Values.extraEnvVars }}
-            {{- include "openinwoner.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 16 }}
+            {{- include "openinwoner.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           command:
             - "/bin/bash"
             - "-c"
           args:
-          - |
-            /wait_for_db.sh
-            /app/src/manage.py migrate
-            /app/src/manage.py search_index --rebuild -f
+            - |
+              /wait_for_db.sh
+              python /app/src/manage.py cms4_migration
           volumeMounts:
             - name: media
-              mountPath: /app/private-media
+              mountPath: /app/private_media
               subPath: {{ .Values.persistence.privateMediaMountSubpath | default "openinwoner/private_media" }}
             - name: media
               mountPath: /app/media
@@ -68,7 +66,42 @@ spec:
             {{- if .Values.extraVolumeMounts }}
             {{- include "openinwoner.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
-        {{- end }}        
+        {{- end }}
+        {{- if .Values.settings.searchIndexInitContainer }}
+        - name: {{ .Chart.Name }}-search-index
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.existingSecret | default (include "openinwoner.fullname" .) }}
+            - configMapRef:
+                name: {{ include "openinwoner.fullname" . }}
+          env:
+            {{- if .Values.extraEnvVars }}
+            {{- include "openinwoner.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          command:
+            - "/bin/bash"
+            - "-c"
+          args:
+            - |
+              /wait_for_db.sh
+              /app/src/manage.py migrate
+              /app/src/manage.py search_index --rebuild -f
+          volumeMounts:
+            - name: media
+              mountPath: /app/private_media
+              subPath: {{ .Values.persistence.privateMediaMountSubpath | default "openinwoner/private_media" }}
+            - name: media
+              mountPath: /app/media
+              subPath: {{ .Values.persistence.mediaMountSubpath  | default "openinwoner/media" }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "openinwoner.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $ ) | nindent 12 }}
+            {{- end }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/openinwoner/templates/deployment.yaml
+++ b/charts/openinwoner/templates/deployment.yaml
@@ -459,6 +459,109 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: {{ include "openinwoner.lowLatencyWorkerFullname" . }}
+  labels:
+    {{- include "openinwoner.lowLatencyWorkerLabels" . | nindent 4 }}
+spec:
+  {{- if not .Values.lowLatencyWorker.autoscaling.enabled }}
+  replicas: {{ .Values.lowLatencyWorker.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "openinwoner.lowLatencyWorkerSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+    {{- include "openinwoner.lowLatencyWorkerSelectorLabels" . | nindent 8 }}
+    {{- with .Values.lowLatencyWorker.podLabels }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "openinwoner.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "openinwoner.lowLatencyWorkerFullname" . }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.existingSecret | default (include "openinwoner.fullname" .) }}
+            - configMapRef:
+                name: {{ include "openinwoner.fullname" . }}
+          env:
+            - name: CELERY_WORKER_QUEUE
+              value: {{ .Values.lowLatencyWorker.queue | quote }}
+            - name: CELERY_WORKER_CONCURRENCY
+              value: {{ .Values.lowLatencyWorker.concurrency | toString | quote }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "openinwoner.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          {{- if .Values.lowLatencyWorker.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+            {{- toYaml .Values.lowLatencyWorker.livenessProbe.exec | nindent 14 }}
+            initialDelaySeconds: {{ .Values.lowLatencyWorker.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.lowLatencyWorker.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.lowLatencyWorker.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.lowLatencyWorker.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.lowLatencyWorker.livenessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.lowLatencyWorker.resources | nindent 12 }}
+          command:
+            - /celery_worker.sh
+          volumeMounts:
+            - name: media
+              mountPath: /app/private_media
+              subPath: {{ .Values.persistence.privateMediaMountSubpath | default "openinwoner/private_media" }}
+            - name: media
+              mountPath: /app/media
+              subPath: {{ .Values.persistence.mediaMountSubpath  | default "openinwoner/media" }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "openinwoner.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $ ) | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: media
+          persistentVolumeClaim:
+          {{- if .Values.persistence.enabled }}
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "openinwoner.fullname" . }}{{- end }}
+          {{- else }}
+          emptyDir: { }
+          {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "openinwoner.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: {{ include "openinwoner.nginxFullname" . }}
   labels:
     {{- include "openinwoner.nginxLabels" . | nindent 4 }}

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -452,6 +452,9 @@ settings:
   # of the ZGW backend's zaken endpoint.
   zgwMaxRequests: ""
 
+  # -- Timeout in seconds for cached ZGW zaken requests. Leave empty to use the application default.
+  cacheZgwZakenTimeout: ""
+
   otel:
     disabled: true
     # -- Network address where to send the metrics to. Examples are: https://otel.example.com:4318 or http://otel-collector.namespace.cluster.svc:4317.

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -16,7 +16,7 @@ configuration:
     enabled: true
     backoffLimit: 6
     # -- 0 Will clean the job after it is finished
-    ttlSecondsAfterFinished: 0    
+    ttlSecondsAfterFinished: 0
     restartPolicy: OnFailure
     # Note, this field is immutable
     resources: {}
@@ -35,10 +35,10 @@ configuration:
   #     items:
   #     - identifier: admin-oidc
   #       enabled: True
-  #       oidc_rp_client_id: openinwoner.example.nl 
+  #       oidc_rp_client_id: openinwoner.example.nl
   #       oidc_rp_client_secret:
   #         value_from:
-  #           env: keycloak_client_secret   
+  #           env: keycloak_client_secret
   #       oidc_rp_scopes_list:
   #       - openid
   #       - email
@@ -77,7 +77,7 @@ configuration:
   #         client_id: openinwoner
   #         secret:
   #           value_from:
-  #             env: openzaak_openinwoner_secret 
+  #             env: openzaak_openinwoner_secret
   #       - identifier: documenten-test
   #         label: Open Zaak - Documenten API
   #         api_root: https://openzaak.example.nl/documenten/api/v1/
@@ -183,14 +183,14 @@ podSecurityContext:
 securityContext:
   capabilities:
     drop:
-    - ALL
+      - ALL
   readOnlyRootFilesystem: false
   runAsNonRoot: true
   runAsUser: 1000
 
 startupProbe:
   # -- Startup probe configuration - allows up to 5 minutes for application startup
-  # -- Total time: 15s initial delay + (30 failures × 10s period) = 315s (5 minutes 15 seconds)    
+  # -- Total time: 15s initial delay + (30 failures × 10s period) = 315s (5 minutes 15 seconds)
   initialDelaySeconds: 15
   periodSeconds: 10
   timeoutSeconds: 5
@@ -351,7 +351,7 @@ settings:
   secretKey: ""
 
   # -- This optional setting can be used to rotate a secret key, by moving a new value
-  # into secretKey, and moving the previous secretKey into secretKeyFallback. 
+  # into secretKey, and moving the previous secretKey into secretKeyFallback.
   secretKeyFallback: ""
 
   environment: null
@@ -425,6 +425,13 @@ settings:
 
   # -- Runs a init container that will run /app/src/manage.py search_index --rebuild -f. You might want to enable this one time for new deployments if you want to prevent 500 errors when using the search function
   searchIndexInitContainer: false
+
+  # -- Runs an init container that executes `python /app/src/manage.py cms4_migration`.
+  # Enabled by default to ensure the migration runs on the initial rollout to 2.3.0.
+  # This migration only needs to run once: once it has completed successfully, set this
+  # to false to avoid re-running it on every pod restart.
+  cms4MigrationInitContainer: true
+
   # -- Custom JavaScript Configuration
   # Flag to enable the custom JavaScript upload feature in the admin interface. When set to true, this feature allows admins to upload custom JavaScript code that will be loaded on all pages.
   # WARNING: Custom JavaScript can negatively impact security and performance, and should be done with care.
@@ -550,7 +557,7 @@ nginx:
   securityContext:
     capabilities:
       drop:
-      - ALL
+        - ALL
     readOnlyRootFilesystem: false
     runAsNonRoot: true
     runAsUser: 101
@@ -573,7 +580,6 @@ nginx:
     #   cpu: 250m
     #   memory: 256Mi
 
-
 ##################
 # Redis subchart #
 ##################
@@ -591,11 +597,11 @@ redis:
       requests:
         cpu: 250m
         memory: 256Mi
-  # -- Redis image configuration - Migration from Bitnami to official Redis image          
+  # -- Redis image configuration - Migration from Bitnami to official Redis image
   image:
-    registry: docker.io  # Docker registry for Redis image
-    repository: redis  # Official Redis image (migrated from Bitnami)
-    tag: "8.0"  # Official Redis image pinned version
+    registry: docker.io # Docker registry for Redis image
+    repository: redis # Official Redis image (migrated from Bitnami)
+    tag: "8.0" # Official Redis image pinned version
 
 #########################
 # ECK-Operator subchart #
@@ -1129,160 +1135,158 @@ eck-elasticsearch:
   # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-node-configuration.html
   #
   nodeSets:
-  - name: default
-    count: 1
-    config:
-      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
-      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
-      # and leave node.store.allow_mmap unset.
-      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
-      #
-      node.store.allow_mmap: false
-    podTemplate:
-      # The following spec is exactly the Kubernetes Core V1 PodTemplateSpec. Any fields within the PodTemplateSpec
-      # are supported within the 'spec' field below.  Please see below documentation for the exhaustive list of fields.
-      #
-      # https://v1-24.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podtemplatespec-v1-core
-      #
-      # Only the commonly overridden/used fields will be noted below.
-      #
-      spec:
+    - name: default
+      count: 1
+      config:
+        # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+        # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+        # and leave node.store.allow_mmap unset.
+        # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+        #
+        node.store.allow_mmap: false
+      podTemplate:
+        # The following spec is exactly the Kubernetes Core V1 PodTemplateSpec. Any fields within the PodTemplateSpec
+        # are supported within the 'spec' field below.  Please see below documentation for the exhaustive list of fields.
+        #
+        # https://v1-24.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podtemplatespec-v1-core
+        #
+        # Only the commonly overridden/used fields will be noted below.
+        #
+        spec:
+          # If specified, the pod's scheduling constraints
+          # https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html
+          # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+          # affinity:
+          #   nodeAffinity:
+          #     requiredDuringSchedulingIgnoredDuringExecution:
+          #       nodeSelectorTerms:
+          #       - matchExpressions:
+          #         - key: topology.kubernetes.io/zone
+          #           operator: In
+          #           values:
+          #           - antarctica-east1
+          #           - antarctica-west1
 
-        # If specified, the pod's scheduling constraints
+          # Containers array.  Should only be used to customize the 'elasticsearch' container using the following fields.
+          containers:
+            - name: elasticsearch
+
+              # List of environment variables to set in the 'elasticsearch' container.
+              # https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+              # env:
+              # - name: "my-env-var"
+              #   value: "my-value"
+
+              # Compute Resources required by this container.
+              resources:
+                # Requests describes the minimum amount of compute resources required. If Requests is omitted for a container,
+                # it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value.
+                #
+                # Defaults used by the ECK Operator, if not specified, are below
+                limits:
+                  # cpu: 1
+                  memory: 2Gi
+                requests:
+                  # cpu: 1
+                  memory: 2Gi
+
+                # Example increasing both the requests and limits values:
+                # limits:
+                #   cpu: 4
+                #   memory: 8Gi
+                # requests:
+                #   cpu: 1
+                #   memory: 8Gi
+
+              # SecurityContext defines the security options the container should be run with.
+              # If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+              #
+              # These typically are set automatically by the ECK Operator, and should only be adjusted
+              # with the full knowledge of the effects of each field.
+              #
+              # securityContext:
+
+              # Whether this container has a read-only root filesystem. Default is false.
+              # readOnlyRootFilesystem: false
+
+              # The GID to run the entrypoint of the container process. Uses runtime default if unset.
+              # runAsGroup: 1000
+
+              # Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure
+              # that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed.
+              # runAsNonRoot: true
+
+              # The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified.
+              # runAsUser: 1000
+
+        # ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+        # https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+        # imagePullSecrets:
+        # - name: "image-pull-secret"
+
+        # List of initialization containers belonging to the pod.
+        #
+        # Common initContainers include setting sysctl, or in 7.x versions of Elasticsearch,
+        # installing Elasticsearch plugins.
+        #
+        # https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+        # initContainers:
+        # - command:
+        #   - sh
+        #   - "-c"
+        #   - sysctl -w vm.max_map_count=262144
+        #   name: sysctl
+        #   securityContext:
+        #     privileged: true
+        # - command:
+        #   - sh
+        #   - "-c"
+        #   - bin/elasticsearch-plugin remove --purge analysis-icu ; bin/elasticsearch-plugin install --batch analysis-icu
+        #   name: install-plugins
+        #   securityContext:
+        #     privileged: true
+
+        # NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node.
+        # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
         # https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html
-        # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
-        # affinity:
-        #   nodeAffinity:
-        #     requiredDuringSchedulingIgnoredDuringExecution:
-        #       nodeSelectorTerms:
-        #       - matchExpressions:
-        #         - key: topology.kubernetes.io/zone
-        #           operator: In
-        #           values:
-        #           - antarctica-east1
-        #           - antarctica-west1
+        # nodeSelector:
+        #   diskType: ssd
+        #   environment: production
 
-        # Containers array.  Should only be used to customize the 'elasticsearch' container using the following fields.
-        containers:
-        - name: elasticsearch
+        # If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority.
+        # Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+        # https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+        # priorityClassName: ""
 
-          # List of environment variables to set in the 'elasticsearch' container.
-          # https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
-          # env:
-          # - name: "my-env-var"
-          #   value: "my-value"
+        # SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty. See type description for default values of each field.
+        # See previously defined 'securityContext' within 'podTemplate' for all available fields.
+        # securityContext: {}
 
-          # Compute Resources required by this container.
-          resources:
-            # Requests describes the minimum amount of compute resources required. If Requests is omitted for a container,
-            # it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value.
-            #
-            # Defaults used by the ECK Operator, if not specified, are below
-            limits:
-              # cpu: 1
-              memory: 2Gi
-            requests:
-              # cpu: 1
-              memory: 2Gi
+        # ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+        # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+        # serviceAccountName: ""
 
-            # Example increasing both the requests and limits values:
-            # limits:
-            #   cpu: 4
-            #   memory: 8Gi
-            # requests:
-            #   cpu: 1
-            #   memory: 8Gi
+        # Optional duration in seconds to wait for the Elasticsearch pod to terminate gracefully.
+        # terminationGracePeriodSeconds: 30s
 
-          # SecurityContext defines the security options the container should be run with.
-          # If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-          #
-          # These typically are set automatically by the ECK Operator, and should only be adjusted
-          # with the full knowledge of the effects of each field.
-          #
-          # securityContext:
+        # If specified, the pod's tolerations that will apply to all containers within the pod.
+        # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+        # tolerations:
+        # - key: "node-role.kubernetes.io/elasticsearch"
+        #   effect: "NoSchedule"
+        #   operator: "Exists"
 
-            # Whether this container has a read-only root filesystem. Default is false.
-            # readOnlyRootFilesystem: false
+        # TopologySpreadConstraints describes how a group of pods ought to spread across topology domains.
+        # Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
+        #
+        # These settings are generally applied within each `nodeSets[].podTemplate` field to apply to a specific Elasticsearch nodeset.
+        #
+        # https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html
+        # topologySpreadConstraints: {}
 
-            # The GID to run the entrypoint of the container process. Uses runtime default if unset.
-            # runAsGroup: 1000
-
-            # Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure
-            # that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed.
-            # runAsNonRoot: true
-
-            # The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified.
-            # runAsUser: 1000
-
-      # ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
-      # https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
-      # imagePullSecrets:
-      # - name: "image-pull-secret"
-
-      # List of initialization containers belonging to the pod.
-      #
-      # Common initContainers include setting sysctl, or in 7.x versions of Elasticsearch,
-      # installing Elasticsearch plugins.
-      #
-      # https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
-      # initContainers:
-      # - command:
-      #   - sh
-      #   - "-c"
-      #   - sysctl -w vm.max_map_count=262144
-      #   name: sysctl
-      #   securityContext:
-      #     privileged: true
-      # - command:
-      #   - sh
-      #   - "-c"
-      #   - bin/elasticsearch-plugin remove --purge analysis-icu ; bin/elasticsearch-plugin install --batch analysis-icu
-      #   name: install-plugins
-      #   securityContext:
-      #     privileged: true
-
-
-      # NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node.
-      # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-      # https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html
-      # nodeSelector:
-      #   diskType: ssd
-      #   environment: production
-
-      # If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority.
-      # Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
-      # https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
-      # priorityClassName: ""
-
-      # SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty. See type description for default values of each field.
-      # See previously defined 'securityContext' within 'podTemplate' for all available fields.
-      # securityContext: {}
-
-      # ServiceAccountName is the name of the ServiceAccount to use to run this pod.
-      # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-      # serviceAccountName: ""
-
-      # Optional duration in seconds to wait for the Elasticsearch pod to terminate gracefully.
-      # terminationGracePeriodSeconds: 30s
-
-      # If specified, the pod's tolerations that will apply to all containers within the pod.
-      # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-      # tolerations:
-      # - key: "node-role.kubernetes.io/elasticsearch"
-      #   effect: "NoSchedule"
-      #   operator: "Exists"
-
-      # TopologySpreadConstraints describes how a group of pods ought to spread across topology domains.
-      # Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
-      #
-      # These settings are generally applied within each `nodeSets[].podTemplate` field to apply to a specific Elasticsearch nodeset.
-      #
-      # https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html
-      # topologySpreadConstraints: {}
-
-      # List of volumes that can be mounted by containers belonging to the pod.
-      # https://kubernetes.io/docs/concepts/storage/volumes
-      # volumes: []
+        # List of volumes that can be mounted by containers belonging to the pod.
+        # https://kubernetes.io/docs/concepts/storage/volumes
+        # volumes: []
 
   # Settings for controlling Elasticsearch ingress. Enabling ingress will expose your Elasticsearch instance
   # to the public internet, and as such is disabled by default.
@@ -1297,7 +1301,7 @@ eck-elasticsearch:
     enabled: false
 
     # Annotations that will be applied to the Ingress resource. Note that some ingress controllers are controlled via annotations.
-    # 
+    #
     # Nginx Annotations: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/
     #
     # Common annotations:
@@ -1354,4 +1358,3 @@ eck-elasticsearch:
       # Optional Kubernetes secret name that contains a base64 encoded PEM certificate and private key that corresponds to the above 'hosts' definitions.
       # If tls is enabled, but this field is not set, the self-signed certificate and key created by the ECK operator will be used.
       # secretName: chart-example-tls
-

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -503,6 +503,37 @@ worker:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 
+lowLatencyWorker:
+  replicaCount: 1
+  queue: low-latency
+  concurrency: 8
+  podLabels: {}
+  resources: {}
+    # requests:
+    #   cpu: 250m
+    #   memory: 256Mi
+  # Defaults to 60s
+  maxWorkerLivenessDelta: ""
+  livenessProbe:
+    enabled: false
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - celery --workdir src --app open_inwoner.celery inspect --destination celery@${HOSTNAME} active
+    initialDelaySeconds: 60
+    # Periodeseconds should not exceed maxWorkerLivenessDelta
+    periodSeconds: 50
+    timeoutSeconds: 10
+    failureThreshold: 3
+    successThreshold: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+
 beat:
   replicaCount: 1
   podLabels: {}

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -455,6 +455,9 @@ settings:
   # -- Timeout in seconds for cached ZGW zaken requests. Leave empty to use the application default.
   cacheZgwZakenTimeout: ""
 
+  # -- The Celery queue used for cache seeding tasks. Defaults to the low-latency worker queue.
+  cacheSeedingQueue: ""
+
   otel:
     disabled: true
     # -- Network address where to send the metrics to. Examples are: https://otel.example.com:4318 or http://otel-collector.namespace.cluster.svc:4317.


### PR DESCRIPTION
1. Added a config-enabled/disabled init container for the CMS 4 migration
2. Added a new Celery worker specific for low-latency tasks (e.g. caching) and configured the app to do the ZGW pre-fetching there
3. Exposed some new env vars to chart

Tested locally in k3s and seems to work.