### PR TITLE
:arrow_up: [#389] Bump Open Notificaties to 1.16.0

### DIFF
--- a/charts/objecten/templates/configmap.yaml
+++ b/charts/objecten/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   CACHE_OIDC: {{ .Values.settings.cache.oidc | toString | quote }}
   CELERY_BROKER_URL: {{ .Values.settings.celery.brokerUrl | toString | quote }}
-  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackendl | toString | quote }}
+  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackend | toString | quote }}
   {{- end }}
   CELERY_LOGLEVEL:  {{ .Values.settings.celery.logLevel | upper | toString | quote }}
   {{- if .Values.settings.logLevel }}

--- a/charts/openarchiefbeheer/templates/configmap.yaml
+++ b/charts/openarchiefbeheer/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
   CACHE_CHOICES: {{ .Values.settings.cache.choices | toString | quote }}
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   CELERY_BROKER_URL: {{ .Values.settings.celery.brokerUrl | toString | quote }}
-  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackendl | toString | quote }}
+  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackend | toString | quote }}
   {{- end }}
   CELERY_LOGLEVEL:  {{ .Values.settings.celery.logLevel | upper | toString | quote }}
   DB_NAME: {{ .Values.settings.database.name | toString | quote }}

--- a/charts/openforms/templates/configmap.yaml
+++ b/charts/openforms/templates/configmap.yaml
@@ -49,7 +49,7 @@ data:
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   CACHE_PORTALOCKER: {{ .Values.settings.cache.default | toString | quote }}
   CELERY_BROKER_URL: {{ .Values.settings.celery.brokerUrl | toString | quote }}
-  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackendl | toString | quote }}
+  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackend | toString | quote }}
   {{- end }}
   {{ if .Values.worker.maxWorkerLivenessDelta }}
   MAX_WORKER_LIVENESS_DELTA: {{ .Values.worker.maxWorkerLivenessDelta | toString | quote }}

--- a/charts/openinwoner/templates/configmap.yaml
+++ b/charts/openinwoner/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   CACHE_OIDC: {{ .Values.settings.cache.oidc | toString | quote }}
   CELERY_BROKER_URL: {{ .Values.settings.celery.brokerUrl | toString | quote }}
-  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackendl | toString | quote }}
+  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackend | toString | quote }}
   {{- end }}
   CELERY_LOGLEVEL:  {{ .Values.settings.celery.logLevel | upper | toString | quote }}
   DIGID_MOCK: {{ .Values.settings.digidMock | toString | quote }}

--- a/charts/openklant/templates/configmap.yaml
+++ b/charts/openklant/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
   CACHE_DEFAULT: {{ .Values.settings.cache.default | toString | quote }}
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   CELERY_BROKER_URL: {{ .Values.settings.celery.brokerUrl | toString | quote }}
-  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackendl | toString | quote }}
+  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackend | toString | quote }}
   {{- end }}
   CELERY_LOGLEVEL:  {{ .Values.settings.celery.logLevel | upper | toString | quote }}
   DB_NAME: {{ .Values.settings.database.name | toString | quote }}

--- a/charts/opennotificaties/CHANGELOG.md
+++ b/charts/opennotificaties/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.14.0 (XXXX-XX-XX)
+
+- Bumped application version 1.16.0
+
 ## 1.13.1 (2026-02-09)
 
 - Updated the Readme.

--- a/charts/opennotificaties/Chart.lock
+++ b/charts/opennotificaties/Chart.lock
@@ -2,11 +2,8 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 22.0.1
-- name: rabbitmq
-  repository: https://charts.bitnami.com/bitnami
-  version: 16.0.12
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.31.4
-digest: sha256:53c06f5bf6d354174f1d85b1150af6c9465af43996c55534741fc3a6b731be3f
-generated: "2025-08-26T08:49:58.062942306+02:00"
+digest: sha256:f6d1db0bc3e6c719c2cf81b0905885f3b3588880b1a5109027f2f40593f9f05e
+generated: "2026-06-01T12:22:44.126015814+02:00"

--- a/charts/opennotificaties/Chart.yaml
+++ b/charts/opennotificaties/Chart.yaml
@@ -12,11 +12,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - redis
-  - name: rabbitmq
-    version: 16.0.12
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - rabbitmq
   - name: common
     version: 2.31.4
     repository: https://charts.bitnami.com/bitnami

--- a/charts/opennotificaties/Chart.yaml
+++ b/charts/opennotificaties/Chart.yaml
@@ -4,7 +4,7 @@ description: API voor het routeren van notificaties
 
 type: application
 version: 1.13.1
-appVersion: 1.14.0
+appVersion: 1.16.0
 
 dependencies:
   - name: redis

--- a/charts/opennotificaties/README.md
+++ b/charts/opennotificaties/README.md
@@ -2,7 +2,7 @@
 
 API voor het routeren van notificaties
 
-![Version: 1.13.1](https://img.shields.io/badge/Version-1.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=flat-square)
+![Version: 1.13.1](https://img.shields.io/badge/Version-1.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 ## Introduction
 

--- a/charts/opennotificaties/README.md
+++ b/charts/opennotificaties/README.md
@@ -252,7 +252,7 @@ how to configure, see the Open Notificaties [documentation](https://open-notific
 | worker.autoscaling.minReplicas | int | `1` |  |
 | worker.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | worker.autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
-| worker.concurrency | int | `4` |  |
+| worker.concurrency | int | `100` |  |
 | worker.livenessProbe.enabled | bool | `false` |  |
 | worker.livenessProbe.exec.command[0] | string | `"/bin/sh"` |  |
 | worker.livenessProbe.exec.command[1] | string | `"-c"` |  |

--- a/charts/opennotificaties/README.md
+++ b/charts/opennotificaties/README.md
@@ -237,7 +237,7 @@ how to configure, see the Open Notificaties [documentation](https://open-notific
 | settings.secretKey | string | `""` | Generate secret key at https://djecrety.ir/ |
 | settings.sentry.dsn | string | `""` |  |
 | settings.siteDomain | string | `""` | Defines the primary domain where the application is hosted. Defaults to "" |
-| settings.timeLeeway | string | `"nil"` | Time leeway in seconds for JWT validation timestamps Accounts for clock drift between server and client Default: nil (uses Django default, typically 0 seconds) Recommended: not to increase above 300 seconds |
+| settings.timeLeeway | int | `0` | Time leeway in seconds for JWT validation timestamps Accounts for clock drift between server and client Default: nil (uses Django default, typically 0 seconds) Recommended: not to increase above 300 seconds |
 | settings.useXForwardedHost | bool | `true` |  |
 | settings.uwsgi.harakiri | string | `""` |  |
 | settings.uwsgi.master | string | `""` |  |

--- a/charts/opennotificaties/README.md
+++ b/charts/opennotificaties/README.md
@@ -174,6 +174,7 @@ how to configure, see the Open Notificaties [documentation](https://open-notific
 | settings.allowedHosts | string | `""` |  |
 | settings.cache.axes | string | `""` | Sets 'CACHE_AXES' var, only required when tags.redis is false |
 | settings.cache.default | string | `""` | Sets 'CACHE_DEFAULT' var, only required when tags.redis is false |
+| settings.cache.oidc | string | `""` | Sets 'CACHE_OIDC' var, only required when tags.redis is false |
 | settings.celery.brokerUrl | string | `""` | Sets the 'CELERY_BROKER_URL' var |
 | settings.celery.logLevel | string | `"debug"` | Celery loglevel |
 | settings.celery.publishBrokerUrl | string | `""` | Sets the 'PUBLISH_BROKER_URL' var |
@@ -219,6 +220,8 @@ how to configure, see the Open Notificaties [documentation](https://open-notific
 | settings.logLevel | string | `"INFO"` | Default value "INFO" ; Available values are CRITICAL, ERROR, WARNING, INFO and DEBUG |
 | settings.logNotifications | bool | `true` | When set to true notifications are saved to the database and accessible from the admin interface |
 | settings.maxRetries | string | `""` | The maximum number of automatic retries. After this amount of retries, Open Notificaties stops trying to deliver the message. Application default is 5. |
+| settings.notificationLimit | int | `500` | The maximum of scheduled notifications to be handled during ``execute_notifications``. |
+| settings.notificationSecInterval | int | `20` | The amount of seconds between starting the ``execute_notifications`` task that creates the actual notification request tasks (minimum 5 seconds). |
 | settings.numProxies | int | `1` | use 2 if enabling ingress |
 | settings.otel.disabled | bool | `true` |  |
 | settings.otel.exporterOtlpEndpoint | string | `""` | Network address where to send the metrics to. Examples are: https://otel.example.com:4318 or http://otel-collector.namespace.cluster.svc:4317. |

--- a/charts/opennotificaties/README.md
+++ b/charts/opennotificaties/README.md
@@ -25,7 +25,6 @@ helm install opennotificaties maykinmedia/opennotificaties
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | common | 2.31.4 |
-| https://charts.bitnami.com/bitnami | rabbitmq | 16.0.12 |
 | https://charts.bitnami.com/bitnami | redis | 22.0.1 |
 
 ## Configuration and installation details
@@ -147,19 +146,6 @@ how to configure, see the Open Notificaties [documentation](https://open-notific
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
-| rabbitmq.auth.erlangCookie | string | `""` |  |
-| rabbitmq.auth.password | string | `"dummy"` |  |
-| rabbitmq.auth.username | string | `"user"` |  |
-| rabbitmq.clustering.enabled | bool | `false` |  |
-| rabbitmq.extraConfiguration | string | `"consumer_timeout = 86400000"` | RabbitMQ configuration file content This configuration will be appended to the default RabbitMQ configuration It will be mounted as /bitnami/rabbitmq/conf/rabbitmq.conf in the RabbitMQ container The mount name is "configuration" consumer_timeout: RabbitMQ's default consumer timeout is 30 minutes, but OpenNotificaties schedules tasks that can be further in the future. This timeout prevents errors when tasks are scheduled more than 30 minutes ahead. Set to 24 hours (86400000ms) to ensure compatibility. You can customize these settings by modifying the values below |
-| rabbitmq.image.registry | string | `"docker.io"` |  |
-| rabbitmq.image.repository | string | `"bitnamilegacy/rabbitmq"` |  |
-| rabbitmq.image.tag | string | `"4.1.3-debian-12-r0"` |  |
-| rabbitmq.persistence.enabled | bool | `false` |  |
-| rabbitmq.persistence.existingClaim | string | `nil` |  |
-| rabbitmq.persistence.size | string | `"1Gi"` |  |
-| rabbitmq.rbac.create | bool | `false` |  |
-| rabbitmq.resources | object | `{}` |  |
 | readinessProbe.failureThreshold | int | `6` |  |
 | readinessProbe.initialDelaySeconds | int | `30` |  |
 | readinessProbe.periodSeconds | int | `10` |  |
@@ -188,10 +174,9 @@ how to configure, see the Open Notificaties [documentation](https://open-notific
 | settings.allowedHosts | string | `""` |  |
 | settings.cache.axes | string | `""` | Sets 'CACHE_AXES' var, only required when tags.redis is false |
 | settings.cache.default | string | `""` | Sets 'CACHE_DEFAULT' var, only required when tags.redis is false |
-| settings.celery.brokerUrl | string | `""` | Sets the 'CELERY_BROKER_URL' var, only required when tags.rabbitmq is false |
+| settings.celery.brokerUrl | string | `""` | Sets the 'CELERY_BROKER_URL' var |
 | settings.celery.logLevel | string | `"debug"` | Celery loglevel |
-| settings.celery.publishBrokerUrl | string | `""` | Sets the 'PUBLISH_BROKER_URL' var, only required when tags.rabbitmq is false |
-| settings.celery.rabbitmqHost | string | `""` | RabbitMQ server hostname |
+| settings.celery.publishBrokerUrl | string | `""` | Sets the 'PUBLISH_BROKER_URL' var |
 | settings.celery.resultBackend | string | `""` | Sets the 'CELERY_RESULT_BACKEND' var, only required when tags.redis is false |
 | settings.celery.resultExpires | int | `3600` | Sets the 'CELERY_RESULT_EXPIRES' var |
 | settings.cleanOldNotifications.cronjob.historyLimit | int | `1` |  |
@@ -256,7 +241,6 @@ how to configure, see the Open Notificaties [documentation](https://open-notific
 | settings.uwsgi.maxRequests | string | `""` |  |
 | settings.uwsgi.processes | string | `""` |  |
 | settings.uwsgi.threads | string | `""` |  |
-| tags.rabbitmq | bool | `true` |  |
 | tags.redis | bool | `true` |  |
 | tolerations | list | `[]` |  |
 | worker.autoscaling.behavior | object | `{}` |  |

--- a/charts/opennotificaties/templates/configmap.yaml
+++ b/charts/opennotificaties/templates/configmap.yaml
@@ -26,11 +26,6 @@ data:
   CELERY_RESULT_EXPIRES: {{ .Values.settings.celery.resultExpires | toString | quote }}
   {{ if .Values.worker.maxWorkerLivenessDelta }}
   MAX_WORKER_LIVENESS_DELTA: {{ .Values.worker.maxWorkerLivenessDelta | toString | quote }}
-  {{- end }}    
-  {{- if .Values.tags.rabbitmq }}
-  RABBITMQ_HOST: {{ include "common.names.fullname" .Subcharts.rabbitmq | toString | quote }}
-  {{- else }}
-  RABBITMQ_HOST: {{ .Values.settings.celery.rabbitmqHost | toString | quote }}
   {{- end }}
   {{- if .Values.settings.logNotifications }}
   LOG_NOTIFICATIONS_IN_DB: "True"

--- a/charts/opennotificaties/templates/configmap.yaml
+++ b/charts/opennotificaties/templates/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "opennotificaties.labels" . | nindent 4 }}
 data:
   DJANGO_SETTINGS_MODULE: {{ .Values.settings.djangoSettingsModule | toString | quote }}
+  {{- if .Values.settings.useXForwardedHost }}
+  USE_X_FORWARDED_HOST: "True"
+  {{- end }}
   ENVIRONMENT: {{ .Values.settings.environment | default (include "opennotificaties.fullname" .) }}
   {{- if .Values.extraVerifyCerts }}
   EXTRA_VERIFY_CERTS: {{ .Values.extraVerifyCerts | toString | quote }}
@@ -14,9 +17,15 @@ data:
   {{- if .Values.tags.redis }}
   CACHE_DEFAULT: {{ printf "%s-master.%s:6379/0" (include "common.names.fullname" .Subcharts.redis) .Release.Namespace | toString | quote }}
   CACHE_AXES: {{ printf "%s-master.%s:6379/0" (include "common.names.fullname" .Subcharts.redis) .Release.Namespace | toString | quote }}
-  {{- else }}
+  CACHE_OIDC: {{ printf "%s-master.%s:6379/0" (include "common.names.fullname" .Subcharts.redis) .Release.Namespace | toString | quote }}
+  CELERY_BROKER_URL: {{ printf "redis://%s-master.%s:6379/1" (include "common.names.fullname" .Subcharts.redis) .Release.Namespace | toString | quote }}
+  CELERY_RESULT_BACKEND: {{ printf "redis://%s-master.%s:6379/1" (include "common.names.fullname" .Subcharts.redis) .Release.Namespace | toString | quote }}
+  {{ else }}
   CACHE_DEFAULT: {{ .Values.settings.cache.default | toString | quote }}
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
+  CACHE_OIDC: {{ .Values.settings.cache.oidc | toString | quote }}
+  CELERY_BROKER_URL: {{ .Values.settings.celery.brokerUrl | toString | quote }}
+  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackend | toString | quote }}
   {{- end }}
   CELERY_LOGLEVEL:  {{ .Values.settings.celery.logLevel | upper | toString | quote }}
   {{- if .Values.settings.logLevel }}
@@ -44,6 +53,12 @@ data:
   {{- end }}
   {{- if .Values.settings.requestsTimeout }}
   NOTIFICATION_REQUESTS_TIMEOUT: {{ .Values.settings.requestsTimeout | toString | quote }}
+  {{- end }}
+  {{- if .Values.settings.notificationSecInterval }}
+  NOTIFICATION_SEC_INTERVAL: {{ int .Values.settings.notificationSecInterval | quote }}
+  {{- end }}
+  {{- if .Values.settings.notificationLimit }}
+  NOTIFICATION_LIMIT: {{ int .Values.settings.notificationLimit | quote }}
   {{- end }}
   DB_NAME: {{ .Values.settings.database.name | toString | quote }}
   DB_HOST: {{ .Values.global.settings.databaseHost | default .Values.settings.database.host | toString | quote }}

--- a/charts/opennotificaties/templates/secret.yaml
+++ b/charts/opennotificaties/templates/secret.yaml
@@ -6,14 +6,8 @@ metadata:
   labels:
     {{- include "opennotificaties.labels" . | nindent 4 }}
 stringData:
-  {{- if .Values.tags.rabbitmq }}
-  {{ $rabbitmq_url := printf "amqp://%s:%s@%s:5672" .Values.rabbitmq.auth.username .Values.rabbitmq.auth.password (include "common.names.fullname" .Subcharts.rabbitmq) -}}
-  CELERY_BROKER_URL: {{ print $rabbitmq_url "//" | quote }}
-  PUBLISH_BROKER_URL: {{ print $rabbitmq_url "/%2F" | quote }}
-  {{- else }}
   CELERY_BROKER_URL: {{ .Values.settings.celery.brokerUrl | toString | quote }}
   PUBLISH_BROKER_URL: {{ .Values.settings.celery.publishBrokerUrl | toString | quote }}
-  {{- end }}
   {{- if .Values.tags.redis }}
   CELERY_RESULT_BACKEND: {{ printf "redis://%s-master:6379/1" (include "common.names.fullname" .Subcharts.redis) | quote }}
   {{- else }}

--- a/charts/opennotificaties/values.yaml
+++ b/charts/opennotificaties/values.yaml
@@ -492,7 +492,7 @@ settings:
 
 worker:
   replicaCount: 2
-  concurrency: 4
+  concurrency: 100
   podLabels: {}
   resources: {}
   maxWorkerLivenessDelta: ""

--- a/charts/opennotificaties/values.yaml
+++ b/charts/opennotificaties/values.yaml
@@ -357,6 +357,11 @@ settings:
       historyLimit: 1
       resources: {}
 
+  # -- The amount of seconds between starting the ``execute_notifications`` task that creates the actual notification request tasks (minimum 5 seconds).
+  notificationSecInterval: 20
+  # -- The maximum of scheduled notifications to be handled during ``execute_notifications``.
+  notificationLimit: 500
+
   # -- The maximum number of automatic retries. After this amount of retries, Open Notificaties stops trying to deliver the message. Application default is 5.
   maxRetries: ""
   # --  If specified, a factor applied to the exponential backoff. This allows you to tune how quickly automatic retries are performed. Application default is 3.
@@ -429,6 +434,8 @@ settings:
     # When not using the redis subcharts you can set them manually like this:
     # default: myredisserver:6379/0
     # axes: myredisserver:6379/0
+    # -- Sets 'CACHE_OIDC' var, only required when tags.redis is false
+    oidc: ""
 
   celery:
     # -- Celery loglevel

--- a/charts/opennotificaties/values.yaml
+++ b/charts/opennotificaties/values.yaml
@@ -467,7 +467,7 @@ settings:
   # Accounts for clock drift between server and client
   # Default: nil (uses Django default, typically 0 seconds)
   # Recommended: not to increase above 300 seconds
-  timeLeeway: nil  
+  timeLeeway: 0
 
   otel:
     disabled: true

--- a/charts/opennotificaties/values.yaml
+++ b/charts/opennotificaties/values.yaml
@@ -165,7 +165,6 @@ configuration:
 
 tags:
   redis: true
-  rabbitmq: true
 
 replicaCount: 2
 
@@ -434,22 +433,14 @@ settings:
   celery:
     # -- Celery loglevel
     logLevel: debug
-    # -- Sets the 'CELERY_BROKER_URL' var, only required when tags.rabbitmq is false
+    # -- Sets the 'CELERY_BROKER_URL' var
     brokerUrl: ""
     # -- Sets the 'CELERY_RESULT_EXPIRES' var
     resultExpires: 3600
     # -- Sets the 'CELERY_RESULT_BACKEND' var, only required when tags.redis is false
     resultBackend: ""
-    # -- Sets the 'PUBLISH_BROKER_URL' var, only required when tags.rabbitmq is false
+    # -- Sets the 'PUBLISH_BROKER_URL' var
     publishBrokerUrl: ""
-    # -- RabbitMQ server hostname
-    rabbitmqHost: ""
-    # When not using the rabbitmq / redis subcharts you can set them manually like this:
-    #
-    # brokerUrl: amqp://username:password@myrabbitmqbroker:5672//
-    # resultBackend: redis://myredisserver:6379/1
-    # publishBrokerUrl: amqp://username:password@myrabbitmqbroker::5672/%2F
-    # rabbitmqHost: myrabbitmqbroker
 
   isHttps: true
 
@@ -588,48 +579,3 @@ redis:
     registry: docker.io  # Docker registry for Redis image
     repository: redis  # Official Redis image (migrated from Bitnami)
     tag: "8.0"  # Official Redis image pinned version    
-
-#####################
-# RabbitMQ subchart #
-#####################
-
-rabbitmq:
-  auth:
-    username: user
-    # DUMMY PASSWORD: Required for Helm upgrade validation when using existing secrets
-    # This value satisfies the Bitnami chart's upgrade checks but is never used.    
-    password: "dummy"
-    erlangCookie: ""
-    # existingPasswordSecret: opennotificaties-rabbitmq
-    # existingErlangSecret: opennotificaties-rabbitmq    
-    # NOTE: If you remove existingPasswordSecret configuration and want to use direct passwords,
-    # change the password above from "dummy" to your actual RabbitMQ password.     
-  persistence:
-    enabled: false
-    size: 1Gi
-    existingClaim: null
-  resources: {}
-    # limits:
-    #   memory: 1000Mi
-    #   cpu: 500m
-    # requests:
-    #   memory: 300Mi
-    #   cpu: 256m
-  rbac:
-    create: false
-  clustering:
-    enabled: false
-  image:
-    registry: docker.io
-    repository: bitnamilegacy/rabbitmq
-    tag: 4.1.3-debian-12-r0
-  # -- RabbitMQ configuration file content
-  # This configuration will be appended to the default RabbitMQ configuration
-  # It will be mounted as /bitnami/rabbitmq/conf/rabbitmq.conf in the RabbitMQ container
-  # The mount name is "configuration"
-  # consumer_timeout: RabbitMQ's default consumer timeout is 30 minutes, but OpenNotificaties
-  # schedules tasks that can be further in the future. This timeout prevents errors when tasks
-  # are scheduled more than 30 minutes ahead. Set to 24 hours (86400000ms) to ensure compatibility.
-  # You can customize these settings by modifying the values below
-  extraConfiguration: |-
-    consumer_timeout = 86400000

--- a/charts/openobject/templates/configmap.yaml
+++ b/charts/openobject/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   CACHE_OIDC: {{ .Values.settings.cache.oidc | toString | quote }}
   CELERY_BROKER_URL: {{ .Values.settings.celery.brokerUrl | toString | quote }}
-  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackendl | toString | quote }}
+  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackend | toString | quote }}
   {{- end }}
   CELERY_LOGLEVEL:  {{ .Values.settings.celery.logLevel | upper | toString | quote }}
   {{- if .Values.settings.logLevel }}

--- a/charts/openorganisatie/templates/configmap.yaml
+++ b/charts/openorganisatie/templates/configmap.yaml
@@ -20,7 +20,7 @@ data:
   CACHE_DEFAULT: {{ .Values.settings.cache.default | toString | quote }}
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   CELERY_BROKER_URL: {{ .Values.settings.celery.brokerUrl | toString | quote }}
-  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackendl | toString | quote }}
+  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackend | toString | quote }}
   {{- end }}
   CELERY_LOGLEVEL:  {{ .Values.settings.celery.logLevel | upper | toString | quote }}
   {{ if .Values.worker.maxWorkerLivenessDelta }}

--- a/charts/openproduct/templates/configmap.yaml
+++ b/charts/openproduct/templates/configmap.yaml
@@ -20,7 +20,7 @@ data:
   CACHE_DEFAULT: {{ .Values.settings.cache.default | toString | quote }}
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   CELERY_BROKER_URL: {{ .Values.settings.celery.brokerUrl | toString | quote }}
-  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackendl | toString | quote }}
+  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackend | toString | quote }}
   {{- end }}
   CELERY_LOGLEVEL:  {{ .Values.settings.celery.logLevel | upper | toString | quote }}
   DB_NAME: {{ .Values.settings.database.name | toString | quote }}

--- a/charts/openvtb/templates/configmap.yaml
+++ b/charts/openvtb/templates/configmap.yaml
@@ -20,7 +20,7 @@ data:
   CACHE_DEFAULT: {{ .Values.settings.cache.default | toString | quote }}
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   CELERY_BROKER_URL: {{ .Values.settings.celery.brokerUrl | toString | quote }}
-  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackendl | toString | quote }}
+  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackend | toString | quote }}
   {{- end }}
   DB_NAME: {{ .Values.settings.database.name | toString | quote }}
   DB_HOST: {{ .Values.global.settings.databaseHost | default .Values.settings.database.host | toString | quote }}

--- a/charts/openzaak/templates/configmap.yaml
+++ b/charts/openzaak/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
   CACHE_DEFAULT: {{ .Values.settings.cache.default | toString | quote }}
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   CELERY_BROKER_URL: {{ .Values.settings.celery.brokerUrl | toString | quote }}
-  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackendl | toString | quote }}
+  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackend | toString | quote }}
   {{- end }}
   CELERY_LOGLEVEL: {{ .Values.settings.celery.logLevel | upper | toString | quote }}
   CELERY_WORKER_CONCURRENCY: {{ .Values.worker.concurrency | toString | quote }}


### PR DESCRIPTION
Fix #389 
- Bump Open Notificaties to `1.16.0`
- Remove `RabbitMQ`
- Fix and add new values:
   - `settings.notificationLimit`
   - `settings.notificationSecInterval`
- Fix some errors typo
- Increase `CELERY_WORKER_CONCURRENCY` from 4 to 100