### PR TITLE
Release openinwoner chart 2.3.0-rc.1

### DIFF
--- a/charts/openinwoner/CHANGELOG.md
+++ b/charts/openinwoner/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-## 2.2.1 (2026-06-10)
+## 2.3.0 (2026-07-21)
+- Bumped the app version to `2.4.0`.
+- Added `OIDC_USE_LEGACY_ENDPOINTS` setting for DigiD/eHerkenning/eIDAS
+- Removed `CACHE_ZGW_ZAKEN_TIMEOUT` environment variable.
+- Updated celery liveness probes to use maykin-common health checks
 
+## 2.2.1 (2026-06-10)
 - Bumped the app version to `2.3.1`.
 
 ## 2.2.0 (2026-05-29)

--- a/charts/openinwoner/Chart.yaml
+++ b/charts/openinwoner/Chart.yaml
@@ -3,8 +3,8 @@ name: openinwoner
 description: Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
 type: application
-version: 2.2.1
-appVersion: 2.3.1
+version: 2.3.0-rc.1
+appVersion: 2.4.0
 
 icon: https://docs.openinwoner.nl/en/latest/_static/logo.png
 

--- a/charts/openinwoner/README.md
+++ b/charts/openinwoner/README.md
@@ -2,7 +2,7 @@
 
 Platform voor gemeenten en overheden om producten inzichtelijker en toegankelijker te maken voor inwoners.
 
-![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
+![Version: 2.3.0-rc.1](https://img.shields.io/badge/Version-2.3.0--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
 
 ## Introduction
 
@@ -308,9 +308,9 @@ The value of the `DSN` is considered sensitive, so it should be handled as a sec
 | lowLatencyWorker.autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
 | lowLatencyWorker.concurrency | int | `8` |  |
 | lowLatencyWorker.livenessProbe.enabled | bool | `false` |  |
-| lowLatencyWorker.livenessProbe.exec.command[0] | string | `"/bin/sh"` |  |
-| lowLatencyWorker.livenessProbe.exec.command[1] | string | `"-c"` |  |
-| lowLatencyWorker.livenessProbe.exec.command[2] | string | `"celery --workdir src --app open_inwoner.celery inspect --destination celery@${HOSTNAME} active"` |  |
+| lowLatencyWorker.livenessProbe.exec.command[0] | string | `"maykin-common"` |  |
+| lowLatencyWorker.livenessProbe.exec.command[1] | string | `"worker-health-check"` |  |
+| lowLatencyWorker.livenessProbe.exec.command[2] | string | `"--skip ping"` |  |
 | lowLatencyWorker.livenessProbe.failureThreshold | int | `3` |  |
 | lowLatencyWorker.livenessProbe.initialDelaySeconds | int | `60` |  |
 | lowLatencyWorker.livenessProbe.periodSeconds | int | `50` |  |
@@ -432,6 +432,7 @@ The value of the `DSN` is considered sensitive, so it should be handled as a sec
 | settings.loadFixtures | bool | `false` | Will load all fixtures in /app/src/open_inwoner/conf/fixtures/*.json |
 | settings.oidcFrontendLogoutWithHints | bool | `true` | Whether to provide a id_token_hint to the IdP broker when initiating a frontchannel logout |
 | settings.oidcRenewIdTokenExpirySeconds | int | `900` | The session renewal interval for OpenID Connect (DigiD/eHerkenning) in seconds. This configures how often the OIDC session should be renewed. Default is 900 seconds (15 minutes). See chapter 10 of the beheerhandleiding (management manual) for more information. |
+| settings.oidcUseLegacyEndpoints | bool | `true` | Whether the DigiD/eHerkenning/eIDAS OIDC clients use their legacy per-provider callback URLs (true, default) or the shared generic /oidc/callback/ URL (false). Only disable after the IdP broker's redirect URI whitelist has been updated accordingly. See chapter 10 of the beheerhandleiding (management manual) for more information. |
 | settings.otel.disabled | bool | `true` |  |
 | settings.otel.exporterOtlpEndpoint | string | `""` | Network address where to send the metrics to. Examples are: https://otel.example.com:4318 or http://otel-collector.namespace.cluster.svc:4317. |
 | settings.otel.exporterOtlpHeaders | list | `[]` | Any additional HTTP headers, for example if you need Basic auth. This is used in the secret.yaml, as it can contain credentials. |
@@ -471,9 +472,9 @@ The value of the `DSN` is considered sensitive, so it should be handled as a sec
 | worker.autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
 | worker.concurrency | int | `4` |  |
 | worker.livenessProbe.enabled | bool | `false` |  |
-| worker.livenessProbe.exec.command[0] | string | `"/bin/sh"` |  |
-| worker.livenessProbe.exec.command[1] | string | `"-c"` |  |
-| worker.livenessProbe.exec.command[2] | string | `"celery --workdir src --app open_inwoner.celery inspect --destination celery@${HOSTNAME} active"` |  |
+| worker.livenessProbe.exec.command[0] | string | `"maykin-common"` |  |
+| worker.livenessProbe.exec.command[1] | string | `"worker-health-check"` |  |
+| worker.livenessProbe.exec.command[2] | string | `"--skip-ping"` |  |
 | worker.livenessProbe.failureThreshold | int | `3` |  |
 | worker.livenessProbe.initialDelaySeconds | int | `60` |  |
 | worker.livenessProbe.periodSeconds | int | `50` |  |

--- a/charts/openinwoner/README.md
+++ b/charts/openinwoner/README.md
@@ -415,7 +415,9 @@ The value of the `DSN` is considered sensitive, so it should be handled as a sec
 | settings.eherkenningMock | string | `""` |  |
 | settings.elasticapm.token | string | `""` |  |
 | settings.elasticapm.url | string | `""` |  |
-| settings.elasticsearch | object | `{"host":"","password":"","username":""}` | Elasticsearch connection settings, only required when tags.elasticsearch is false |
+| settings.elasticsearch | object | `{"dslAutoRefresh":true,"dslAutosync":true,"host":"","password":"","username":""}` | Elasticsearch connection settings, only required when tags.elasticsearch is false |
+| settings.elasticsearch.dslAutoRefresh | bool | `true` | Refresh affected shards after each index operation so changes are immediately visible in search results. |
+| settings.elasticsearch.dslAutosync | bool | `true` | Update the search index on each model save. Set to false when Elasticsearch is not guaranteed to be available, to avoid 500s on admin operations; the index is then only updated by the periodic Celery index rebuild task. |
 | settings.elasticsearch.host | string | `""` | Elasticsearch hostname |
 | settings.elasticsearch.password | string | `""` | Password for basic authentication (optional) |
 | settings.elasticsearch.username | string | `""` | Username for basic authentication (optional) |

--- a/charts/openinwoner/templates/configmap.yaml
+++ b/charts/openinwoner/templates/configmap.yaml
@@ -93,6 +93,7 @@ data:
   {{- if .Values.settings.oidcRenewIdTokenExpirySeconds }}
   OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS: {{ .Values.settings.oidcRenewIdTokenExpirySeconds | toString | quote }}
   {{- end }}
+  OIDC_USE_LEGACY_ENDPOINTS: {{ .Values.settings.oidcUseLegacyEndpoints | toString | quote }}
   {{- if .Values.settings.zgwMaxRequests }}
   ZGW_MAX_REQUESTS: {{ .Values.settings.zgwMaxRequests | toString | quote }}
   {{- end }}

--- a/charts/openinwoner/templates/configmap.yaml
+++ b/charts/openinwoner/templates/configmap.yaml
@@ -16,6 +16,8 @@ data:
   {{- if .Values.settings.elasticsearch.username }}
   ES_USERNAME: {{ .Values.settings.elasticsearch.username | toString | quote }}
   {{- end }}
+  ELASTICSEARCH_DSL_AUTOSYNC: {{ .Values.settings.elasticsearch.dslAutosync | toString | quote }}
+  ELASTICSEARCH_DSL_AUTO_REFRESH: {{ .Values.settings.elasticsearch.dslAutoRefresh | toString | quote }}
   {{- if .Values.tags.redis }}
   CACHE_DEFAULT: {{ printf "%s-master.%s:6379/0" (include "common.names.fullname" .Subcharts.redis) .Release.Namespace | toString | quote }}
   CACHE_AXES: {{ printf "%s-master.%s:6379/0" (include "common.names.fullname" .Subcharts.redis) .Release.Namespace | toString | quote }}

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -346,6 +346,14 @@ settings:
     username: ""
     # -- Password for basic authentication (optional)
     password: ""
+    # -- Update the search index on each model save. Set to false when
+    # Elasticsearch is not guaranteed to be available, to avoid 500s on admin
+    # operations; the index is then only updated by the periodic Celery
+    # index rebuild task.
+    dslAutosync: true
+    # -- Refresh affected shards after each index operation so changes are
+    # immediately visible in search results.
+    dslAutoRefresh: true
 
   # -- Generate secret key at https://djecrety.ir/
   secretKey: ""

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -493,9 +493,9 @@ worker:
     enabled: false
     exec:
       command:
-        - /bin/sh
-        - -c
-        - celery --workdir src --app open_inwoner.celery inspect --destination celery@${HOSTNAME} active
+        - maykin-common
+        - worker-health-check
+        - --skip-ping
     initialDelaySeconds: 60
     # Periodeseconds should not exceed maxWorkerLivenessDelta
     periodSeconds: 50
@@ -524,9 +524,9 @@ lowLatencyWorker:
     enabled: false
     exec:
       command:
-        - /bin/sh
-        - -c
-        - celery --workdir src --app open_inwoner.celery inspect --destination celery@${HOSTNAME} active
+        - maykin-common
+        - worker-health-check
+        - --skip ping
     initialDelaySeconds: 60
     # Periodeseconds should not exceed maxWorkerLivenessDelta
     periodSeconds: 50

--- a/charts/openinwoner/values.yaml
+++ b/charts/openinwoner/values.yaml
@@ -455,6 +455,13 @@ settings:
   # See chapter 10 of the beheerhandleiding (management manual) for more information.
   oidcRenewIdTokenExpirySeconds: 900
 
+  # -- Whether the DigiD/eHerkenning/eIDAS OIDC clients use their legacy
+  # per-provider callback URLs (true, default) or the shared generic
+  # /oidc/callback/ URL (false). Only disable after the IdP broker's
+  # redirect URI whitelist has been updated accordingly.
+  # See chapter 10 of the beheerhandleiding (management manual) for more information.
+  oidcUseLegacyEndpoints: true
+
   # -- The maximum number of requests allowed for fetching zaken on the Mijn Zaken page.
   # The total number of zaken fetched will be this number multiplied by the page size
   # of the ZGW backend's zaken endpoint.


### PR DESCRIPTION
- Update celery liveness probes to use maykin-common health checks
- Add Elasticsearch DSL autosync/auto-refresh settings
- Add `OIDC_USE_LEGACY_ENDPOINTS` setting for DigiD/eHerkenning/eIDAS (backwards-compatible option for OIDC upgrade)
- Bump openinwoner chart version to 2.3.0-rc.1 and app version to 2.4.0