### PR TITLE
:bug: [#404] Fix bug causing missing django-setup-config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains Helm charts for:
 - [opennotificaties](./charts/opennotificaties/README.md)
 - [openforms](./charts/openforms/README.md)
 - [openinwoner](./charts/openinwoner/README.md)
-- [openobjecten](./charts/objecten/README.md)
+- [objecten](./charts/objecten/README.md)
 - [objecttypen](./charts/objecttypen/README.md)
 - [openarchiefbeheer](./charts/openarchiefbeheer/README.md)
 - [openbeheer](./charts/openbeheer/README.md)

--- a/charts/openobject/README.md
+++ b/charts/openobject/README.md
@@ -249,7 +249,7 @@ The environment variables that the Open Telemetry SDK supports can be found [her
 | settings.otel.resourceAttributes | list | `[]` | Resources Attributes can be used to specify additional information about the instance. |
 | settings.secretKey | string | `""` | Generate secret key at https://djecrety.ir/ |
 | settings.sentry.dsn | string | `""` |  |
-| settings.siteDomain | string | `""` | Defines the primary domain where the application is hosted, Required value |
+| settings.siteDomain | string | `""` | Defines the primary domain where the application is hosted. Required value |
 | settings.useXForwardedHost | bool | `false` |  |
 | settings.uwsgi.harakiri | string | `""` |  |
 | settings.uwsgi.master | string | `""` |  |

--- a/charts/openobject/README.md
+++ b/charts/openobject/README.md
@@ -249,7 +249,7 @@ The environment variables that the Open Telemetry SDK supports can be found [her
 | settings.otel.resourceAttributes | list | `[]` | Resources Attributes can be used to specify additional information about the instance. |
 | settings.secretKey | string | `""` | Generate secret key at https://djecrety.ir/ |
 | settings.sentry.dsn | string | `""` |  |
-| settings.siteDomain | string | `""` | Defines the primary domain where the application is hosted. Defaults to "" |
+| settings.siteDomain | string | `""` | Defines the primary domain where the application is hosted, Required value |
 | settings.useXForwardedHost | bool | `false` |  |
 | settings.uwsgi.harakiri | string | `""` |  |
 | settings.uwsgi.master | string | `""` |  |

--- a/charts/openobject/templates/configmap.yaml
+++ b/charts/openobject/templates/configmap.yaml
@@ -115,9 +115,7 @@ data:
   OBJECTS_SUPERUSER_USERNAME: {{ .Values.configuration.superuser.username | toString | quote }}
   OBJECTS_SUPERUSER_EMAIL: {{ .Values.configuration.superuser.email | toString | quote }}
   {{- end }}
-  {{- if .Values.settings.siteDomain }}
-  SITE_DOMAIN: {{ .Values.settings.siteDomain | toString | quote }}
-  {{- end }}
+  SITE_DOMAIN: {{ required "settings.siteDomain is required" .Values.settings.siteDomain | toString | quote }}
   OBJECTS_ADMIN_SEARCH_DISABLED: {{ if .Values.settings.adminSearchDisabled }}"True"{{ else }}"False"{{ end }}
   OTEL_SDK_DISABLED: {{ if .Values.settings.otel.disabled }}"True"{{ else }}"False"{{ end }}
   {{- if not .Values.settings.otel.disabled }}

--- a/charts/openobject/values.yaml
+++ b/charts/openobject/values.yaml
@@ -28,9 +28,51 @@ configuration:
     # Note, this field is immutable
     resources: {}
   secrets: {}
+    # keycloak_client_secret: keycloak-secret
+    # openformulieren_objecten_token: token123
+    # object_objecttypes_token: token123
   # data: ""
   # e.g.
   # data: |-
+  #   zgw_consumers_config_enable: true
+  #   zgw_consumers:
+  #     services:
+  #     - identifier: notifications-api
+  #       label: Notificaties API
+  #       api_root: https://opennotificaties.example.nl/api/v1/
+  #       api_connection_check_path: notificaties
+  #       api_type: nrc
+  #       auth_type: api_key
+  #       header_key: Authorization
+  #       header_value:
+  #         value_from:
+  #           env: object_notificaties_token 
+  #   notifications_config_enable: true
+  #   notifications_config:
+  #     notifications_api_service_identifier: notifications-api
+  #     notification_delivery_max_retries: 1
+  #     notification_delivery_retry_backoff: 2
+  #     notification_delivery_retry_backoff_max: 3
+  #   tokenauth_config_enable: true
+  #   tokenauth:
+  #     items:
+  #       - identifier: openformulier-token
+  #         token:
+  #           value_from:
+  #             env: openformulieren_objecten_token
+  #         contact_person: Person 1
+  #         email: person-1@example.com
+  #         organization: Organization 1
+  #         application: Application 1
+  #         administration: Administration 1
+  #         permissions:
+  #           - object_type: 366c9b88-a870-438c-b0ec-a121cd51f1dd
+  #             mode: read_and_write
+  #   objecttypes_config_enable: true
+  #   objecttypes:
+  #     items:
+  #       - uuid: 366c9b88-a870-438c-b0ec-a121cd51f1dd
+  #         name: demo
   #   oidc_db_config_enable: true
   #   oidc_db_config_admin_auth:
   #     providers:
@@ -70,7 +112,7 @@ configuration:
   #           default_groups: []
   #           make_users_staff: true
   #           superuser_group_names:
-  #             - Superuser
+  #             - Registreerders
 
 tags:
   redis: true
@@ -297,7 +339,7 @@ settings:
       db_pool_reconnect_timeout: 300
       db_pool_num_workers: 3
 
-  # -- Defines the primary domain where the application is hosted. Defaults to ""
+  # -- Defines the primary domain where the application is hosted, Required value
   siteDomain: ""
   # -- Default value "INFO" ; Available values are CRITICAL, ERROR, WARNING, INFO and DEBUG
   logLevel: "INFO"

--- a/charts/openobject/values.yaml
+++ b/charts/openobject/values.yaml
@@ -339,7 +339,7 @@ settings:
       db_pool_reconnect_timeout: 300
       db_pool_num_workers: 3
 
-  # -- Defines the primary domain where the application is hosted, Required value
+  # -- Defines the primary domain where the application is hosted. Required value
   siteDomain: ""
   # -- Default value "INFO" ; Available values are CRITICAL, ERROR, WARNING, INFO and DEBUG
   logLevel: "INFO"


### PR DESCRIPTION
- Add missing values for `django-setup-configuration` from `objecten/chart`
- Removed: `objecttypes_config_enable` and `sites_config_enable`
- Set `SITE_DOMAIN` required