### PR TITLE
Exposing enableServiceLinks with default value False

### DIFF
--- a/charts/openzaak/CHANGELOG.md
+++ b/charts/openzaak/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.14.2-rc.1 (2026-07-07)
+
+- Exposed enableServiceLinks. Default value is `false`.
+  This fixes the automatic override of `uwsgi_port`, which in turn fixes the problem with the health checks.
+
 ## 1.14.1 (2026-05-07)
 
 - Bumped the application version to 1.28.1.

--- a/charts/openzaak/CHANGELOG.md
+++ b/charts/openzaak/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 1.14.2-rc.1 (2026-07-07)
 
-- Exposed enableServiceLinks. Default value is `false`.
-  This fixes the automatic override of `uwsgi_port`, which in turn fixes the problem with the health checks.
+- Bumped the application version to 1.28.3.
+- Exposed enableServiceLinks for the deployment of the pod that runs the uWSGI server. Default value is `false`.
+  This fixes the automatic override of `OPENZAAK_PORT`, which overrides `uwsgi_port`, which caused the problem with the health checks.
 
 ## 1.14.1 (2026-05-07)
 

--- a/charts/openzaak/Chart.yaml
+++ b/charts/openzaak/Chart.yaml
@@ -3,7 +3,7 @@ name: openzaak
 description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
-version: 1.14.1
+version: 1.14.2-rc.1
 appVersion: 1.28.1
 
 dependencies:

--- a/charts/openzaak/Chart.yaml
+++ b/charts/openzaak/Chart.yaml
@@ -4,7 +4,7 @@ description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
 version: 1.14.2-rc.1
-appVersion: 1.28.1
+appVersion: 1.28.3
 
 dependencies:
   - name: redis

--- a/charts/openzaak/README.md
+++ b/charts/openzaak/README.md
@@ -2,7 +2,7 @@
 
 Productiewaardige API's voor Zaakgericht Werken
 
-![Version: 1.14.2-rc.1](https://img.shields.io/badge/Version-1.14.2--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.28.1](https://img.shields.io/badge/AppVersion-1.28.1-informational?style=flat-square)
+![Version: 1.14.2-rc.1](https://img.shields.io/badge/Version-1.14.2--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.28.3](https://img.shields.io/badge/AppVersion-1.28.3-informational?style=flat-square)
 
 ## Introduction
 

--- a/charts/openzaak/README.md
+++ b/charts/openzaak/README.md
@@ -2,7 +2,7 @@
 
 Productiewaardige API's voor Zaakgericht Werken
 
-![Version: 1.14.1](https://img.shields.io/badge/Version-1.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.28.1](https://img.shields.io/badge/AppVersion-1.28.1-informational?style=flat-square)
+![Version: 1.14.2-rc.1](https://img.shields.io/badge/Version-1.14.2--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.28.1](https://img.shields.io/badge/AppVersion-1.28.1-informational?style=flat-square)
 
 ## Introduction
 
@@ -103,6 +103,7 @@ You can find more information in the Open Zaak documentation for both the [Azure
 | configuration.superuser.email | string | `""` |  |
 | configuration.superuser.password | string | `""` |  |
 | configuration.superuser.username | string | `""` |  |
+| enableServiceLinks | bool | `false` | Prevents K8s from automatically injecting service related environment variables to the pods |
 | existingConfigurationSecrets | string | `nil` |  |
 | existingSecret | string | `nil` |  |
 | extraDeploy | list | `[]` |  |

--- a/charts/openzaak/templates/deployment.yaml
+++ b/charts/openzaak/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/openzaak/values.yaml
+++ b/charts/openzaak/values.yaml
@@ -153,6 +153,9 @@ podAnnotations: {}
 
 podLabels: {}
 
+# -- Prevents K8s from automatically injecting service related environment variables to the pods
+enableServiceLinks: false
+
 podSecurityContext:
   fsGroup: 1000
 


### PR DESCRIPTION
Exposing enableServiceLinks with default value False to fix health check issue described in https://taiga.maykinmedia.nl/project/dimpact-enschede-ssc-ict-1/issue/519

When this variable is set to True, OPENZAAK_PORT is automatically overwritten and this in turn overwrites the value of uwsgi_port. That causes problems with the health checks when Open Zaak is run in Kubernetes.