### PR TITLE
feat(openzaak): gate celery beat Deployment behind beat.enabled

### DIFF
--- a/charts/openzaak/CHANGELOG.md
+++ b/charts/openzaak/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Added `beat.enabled` (default `true`) to gate the Celery beat scheduler Deployment.
+  Set it to `false` to omit the beat Deployment entirely, mirroring `flower.enabled`.
+  Previously the beat Deployment was rendered unconditionally and could only be scaled
+  down via `beat.replicaCount: 0`, which left an idle 0-replica Deployment behind.
+
 ## 1.14.2 (2026-07-07)
 
 - Bumped the application version to 1.28.3.

--- a/charts/openzaak/README.md
+++ b/charts/openzaak/README.md
@@ -79,6 +79,7 @@ You can find more information in the Open Zaak documentation for both the [Azure
 | azureVaultSecret.objectName | string | `""` |  |
 | azureVaultSecret.secretName | string | `"{{ .Values.existingSecret }}"` |  |
 | azureVaultSecret.vaultName | string | `nil` |  |
+| beat.enabled | bool | `true` | Deploy the Celery beat scheduler. Set to false to omit the beat Deployment entirely. |
 | beat.livenessProbe.failureThreshold | int | `6` |  |
 | beat.livenessProbe.initialDelaySeconds | int | `60` |  |
 | beat.livenessProbe.periodSeconds | int | `10` |  |

--- a/charts/openzaak/templates/deployment.yaml
+++ b/charts/openzaak/templates/deployment.yaml
@@ -385,7 +385,7 @@ spec:
       {{- end }}
 {{- end }}
 ---
-
+{{ if .Values.beat.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -470,3 +470,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/openzaak/values.yaml
+++ b/charts/openzaak/values.yaml
@@ -587,6 +587,8 @@ flower:
   resources: {}
 
 beat:
+  # -- Deploy the Celery beat scheduler. Set to false to omit the beat Deployment entirely.
+  enabled: true
   replicaCount: 1
   podLabels: {}
   livenessProbe:


### PR DESCRIPTION
## What
Adds a `beat.enabled` value (default `true`) to the openzaak chart and wraps the Celery beat `Deployment` in it, mirroring the existing `flower.enabled` guard.

## Why
The beat `Deployment` in `templates/deployment.yaml` is currently rendered unconditionally, while the sibling `flower` Deployment is guarded by `{{ if .Values.flower.enabled -}}`. There is no `beat.enabled` key, so operators who don't want the scheduler have no way to omit it — setting `beat.replicaCount: 0` leaves an idle 0-replica Deployment behind, and `beat.enabled: false` is silently ignored. This is still the case on the current `main`.

For context on why omitting beat is a reasonable thing to want: Open Zaak's beat schedule contains a single periodic task, `daily-remove-imports` (`remove_imports`), which is housekeeping for the bulk document-import feature — deployments that don't use bulk import have no work for beat to do and may prefer not to run the Deployment at all.

## Changes
- `values.yaml`: add `beat.enabled: true` (documented).
- `templates/deployment.yaml`: wrap the beat Deployment in `{{ if .Values.beat.enabled -}} … {{- end }}`.
- CHANGELOG entry (under `Unreleased`; version bump left to the release process).
- Regenerated README row for `beat.enabled`.

## Backwards compatibility
Default is `true`, so existing installs render the beat Deployment exactly as before. Only explicitly setting `beat.enabled: false` changes behaviour.

## Testing
`helm lint` passes. `helm template` verified: default still renders beat; `--set beat.enabled=false` omits only beat, leaving worker and flower untouched.
