### PR TITLE
:bug: OpenKlant chart fix worker-health-check with new format

### DIFF
--- a/charts/openklant/templates/deployment.yaml
+++ b/charts/openklant/templates/deployment.yaml
@@ -195,7 +195,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - maykin-common worker-health-check --skip-ping --skip-event-loop-liveness --no-skip-startup --startup-file=/app/tmp/celery_worker.ready
+              - maykin-common worker-health-check --skip-ping --skip-event-loop-liveness --no-skip-readiness --readiness-file=/app/tmp/celery_worker.ready
             initialDelaySeconds: {{ .Values.worker.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.worker.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.worker.startupProbe.timeoutSeconds }}


### PR DESCRIPTION
While testing https://github.com/maykinmedia/charts/pull/425, I encountered this error

Caused by new version of django-common